### PR TITLE
Double le nombre de slots wildcard des ids

### DIFF
--- a/code/__DEFINES/id_cards.dm
+++ b/code/__DEFINES/id_cards.dm
@@ -11,12 +11,12 @@
  */
 
 /// Wildcard slot define for basic grey cards. Only hold 2 common wildcards.
-#define WILDCARD_LIMIT_GREY list(WILDCARD_NAME_COMMON = list(limit = 2, usage = list()))
+#define WILDCARD_LIMIT_GREY list(WILDCARD_NAME_COMMON = list(limit = 4, usage = list()))
 /// Wildcard slot define for Head of Staff silver cards. Can hold 3 common, 1 command and 1 private command.
 #define WILDCARD_LIMIT_SILVER list( \
-	WILDCARD_NAME_COMMON = list(limit = 3, usage = list()), \
-	WILDCARD_NAME_COMMAND = list(limit = 1, usage = list()), \
-	WILDCARD_NAME_PRV_COMMAND = list(limit = 1, usage = list()) \
+	WILDCARD_NAME_COMMON = list(limit = 6, usage = list()), \
+	WILDCARD_NAME_COMMAND = list(limit = 2, usage = list()), \
+	WILDCARD_NAME_PRV_COMMAND = list(limit = 2, usage = list()) \
 )
 /// Wildcard slot define for Captain gold cards. Can hold infinite of any Captain level wildcard.
 #define WILDCARD_LIMIT_GOLD list(WILDCARD_NAME_CAPTAIN = list(limit = -1, usage = list()))
@@ -30,8 +30,8 @@
 #define WILDCARD_LIMIT_PRISONER list()
 /// Wildcard slot define for Chameleon/Agent ID grey cards. Can hold 3 common, 1 command and 1 captain access.
 #define WILDCARD_LIMIT_CHAMELEON list( \
-	WILDCARD_NAME_COMMON = list(limit = 3, usage = list()), \
-	WILDCARD_NAME_COMMAND = list(limit = 1, usage = list()), \
+	WILDCARD_NAME_COMMON = list(limit = 6, usage = list()), \
+	WILDCARD_NAME_COMMAND = list(limit = 2, usage = list()), \
 	WILDCARD_NAME_CAPTAIN = list(limit = 1, usage = list()) \
 )
 /// Wildcard slot define for admin/debug/weird, special abstract cards. Can hold infinite of any access.


### PR DESCRIPTION
Double le nombre de slot wildcard common et command pour toutes les ids.
Cela semble plus adapté a notre mode de jeu lowpop ou il est fréquant qu'un joueur fasse 2 metier (et devrait se trimballer 2 ids avec le faible nb de wildcard pour le moment).
Cad : 
Badge basique : 2 -> 4 common wildcard
Badge silver : 3 -> 6 common wildcard, 1 -> 2 command wildcard, 1 -> 2 private command wildcard
Badge camélon : 3 -> 6 common wildcard, 1 -> 2 command wildcard