### PR TITLE
Insanity part 1 : Ajout/Rebalance/Fix syteme moral et sanite. 

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -549,4 +549,5 @@ GLOBAL_LIST_INIT(pda_styles, sortList(list(MONO, VT, ORBITRON, SHARE)))
 //while using the SKILLCHIP_RESTRICTED_CATEGORIES flag
 #define SKILLCHIP_CATEGORY_GENERAL "general"
 #define SKILLCHIP_CATEGORY_JOB "job"
+#define SKILLCHIP_CATEGORY_FUN_VOICE "fun voice"
 #define SKILLCHIP_CATEGORY_FIREMAN_CARRYING "fireman carrying"

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -144,14 +144,15 @@
 #define SCREWYDOLL_R_LEG /obj/item/bodypart/r_leg
 
 //Threshold levels for beauty for humans
-#define BEAUTY_LEVEL_HORRID -66
-#define BEAUTY_LEVEL_BAD -33
-#define BEAUTY_LEVEL_DECENT 33
-#define BEAUTY_LEVEL_GOOD 66
-#define BEAUTY_LEVEL_GREAT 100
+#define BEAUTY_LEVEL_HORRID -40
+#define BEAUTY_LEVEL_BAD -15
+#define BEAUTY_LEVEL_SCRUFFY 5
+#define BEAUTY_LEVEL_DECENT 30
+#define BEAUTY_LEVEL_GOOD 60
+#define BEAUTY_LEVEL_GREAT 90
 
 //Moods levels for humans
-#define MOOD_LEVEL_HAPPY4 15
+#define MOOD_LEVEL_HAPPY4 20
 #define MOOD_LEVEL_HAPPY3 10
 #define MOOD_LEVEL_HAPPY2 6
 #define MOOD_LEVEL_HAPPY1 2
@@ -162,12 +163,12 @@
 #define MOOD_LEVEL_SAD4 -20
 
 //Sanity levels for humans
-#define SANITY_MAXIMUM 150
-#define SANITY_GREAT 125
-#define SANITY_NEUTRAL 100
-#define SANITY_DISTURBED 75
-#define SANITY_UNSTABLE 50
-#define SANITY_CRAZY 25
+#define SANITY_MAXIMUM 200
+#define SANITY_GREAT 175
+#define SANITY_NEUTRAL 145
+#define SANITY_DISTURBED 105
+#define SANITY_UNSTABLE 70
+#define SANITY_CRAZY 30
 #define SANITY_INSANE 0
 
 //Nutrition levels for humans

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -96,7 +96,7 @@
 
 ///Called after moodevent/s have been added/removed.
 /datum/component/mood/proc/update_mood()
-	mood = 0
+	mood = -sanity_level
 	shown_mood = 0
 	for(var/i in mood_events)
 		var/datum/mood_event/event = mood_events[i]
@@ -179,21 +179,21 @@
 		if(1)
 			setSanity(sanity-0.3*delta_time, SANITY_INSANE)
 		if(2)
-			setSanity(sanity-0.15*delta_time, SANITY_INSANE)
+			setSanity(sanity+mood*delta_time/100, SANITY_INSANE)
 		if(3)
-			setSanity(sanity-0.1*delta_time, SANITY_CRAZY)
+			setSanity(sanity+mood*delta_time/100, SANITY_INSANE)
 		if(4)
-			setSanity(sanity-0.05*delta_time, SANITY_UNSTABLE)
+			setSanity(sanity+mood*delta_time/100, SANITY_INSANE)
 		if(5)
-			setSanity(sanity, SANITY_UNSTABLE) //This makes sure that mood gets increased should you be below the minimum.
+			setSanity(sanity+mood*delta_time/100, SANITY_INSANE) //This makes sure that mood gets increased should you be below the minimum.
 		if(6)
-			setSanity(sanity+0.2*delta_time, SANITY_UNSTABLE)
+			setSanity(sanity+mood*delta_time/70, SANITY_CRAZY)
 		if(7)
-			setSanity(sanity+0.3*delta_time, SANITY_UNSTABLE)
+			setSanity(sanity+mood*delta_time/70, SANITY_CRAZY)
 		if(8)
-			setSanity(sanity+0.4*delta_time, SANITY_NEUTRAL, SANITY_MAXIMUM)
+			setSanity(sanity+mood*delta_time/60, SANITY_UNSTABLE, SANITY_MAXIMUM)
 		if(9)
-			setSanity(sanity+0.6*delta_time, SANITY_NEUTRAL, SANITY_MAXIMUM)
+			setSanity(sanity+0.5*delta_time, SANITY_NEUTRAL, SANITY_MAXIMUM)
 	HandleNutrition()
 
 	// 0.416% is 15 successes / 3600 seconds. Calculated with 2 minute
@@ -215,25 +215,35 @@
 		amount += clamp(minimum - amount, 0, 0.7)
 	if((!override && HAS_TRAIT(parent, TRAIT_UNSTABLE)) || amount > maximum)
 		amount = min(sanity, amount)
+	var/mob/living/carbon/master = parent
 	if(amount == sanity) //Prevents stuff from flicking around.
+		switch(sanity)
+			if(SANITY_INSANE to SANITY_CRAZY)
+				master.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.25, 120)
+			if(SANITY_CRAZY to SANITY_UNSTABLE)
+				master.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.1, 60)
+			if(SANITY_GREAT+1 to INFINITY)
+				master.adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.1)
 		return
 	sanity = amount
-	var/mob/living/master = parent
 	switch(sanity)
 		if(SANITY_INSANE to SANITY_CRAZY)
 			setInsanityEffect(MAJOR_INSANITY_PEN)
 			master.add_movespeed_modifier(/datum/movespeed_modifier/sanity/insane)
 			master.add_actionspeed_modifier(/datum/actionspeed_modifier/low_sanity)
+			master.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.25, 120)
 			sanity_level = 6
 		if(SANITY_CRAZY to SANITY_UNSTABLE)
 			setInsanityEffect(MINOR_INSANITY_PEN)
 			master.add_movespeed_modifier(/datum/movespeed_modifier/sanity/crazy)
 			master.add_actionspeed_modifier(/datum/actionspeed_modifier/low_sanity)
+			master.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.1, 60)
 			sanity_level = 5
 		if(SANITY_UNSTABLE to SANITY_DISTURBED)
 			setInsanityEffect(0)
 			master.add_movespeed_modifier(/datum/movespeed_modifier/sanity/disturbed)
 			master.add_actionspeed_modifier(/datum/actionspeed_modifier/low_sanity)
+			master.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.05, 20)
 			sanity_level = 4
 		if(SANITY_DISTURBED to SANITY_NEUTRAL)
 			setInsanityEffect(0)
@@ -249,6 +259,7 @@
 			setInsanityEffect(0)
 			master.remove_movespeed_modifier(MOVESPEED_ID_SANITY)
 			master.add_actionspeed_modifier(/datum/actionspeed_modifier/high_sanity)
+			master.adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.1)
 			sanity_level = 1
 	update_mood_icon()
 
@@ -379,8 +390,11 @@
 	SIGNAL_HANDLER
 
 	update_beauty(A)
-	if(A.mood_bonus && (!A.mood_trait || HAS_TRAIT(source, A.mood_trait)))
-		add_event(null, "area", /datum/mood_event/area, A.mood_bonus, A.mood_message)
+	if(A.mood_bonus)
+		if( (!A.mood_trait || !HAS_TRAIT(source, A.mood_trait)))
+			add_event(null, "area", /datum/mood_event/area, A.mood_bonus, A.mood_message)
+		else
+			add_event(null, "area", /datum/mood_event/area, A.mood_bonus*2, A.mood_message)
 	else
 		clear_event(null, "area")
 
@@ -388,16 +402,26 @@
 	if(A.outdoors) //if we're outside, we don't care.
 		clear_event(null, "area_beauty")
 		return FALSE
+
 	if(HAS_TRAIT(parent, TRAIT_SNOB))
 		switch(A.beauty)
 			if(-INFINITY to BEAUTY_LEVEL_HORRID)
-				add_event(null, "area_beauty", /datum/mood_event/horridroom)
+				add_event(null, "area_beauty", /datum/mood_event/horridroomsnob)
 				return
 			if(BEAUTY_LEVEL_HORRID to BEAUTY_LEVEL_BAD)
-				add_event(null, "area_beauty", /datum/mood_event/badroom)
+				add_event(null, "area_beauty", /datum/mood_event/badroomsnob)
+				return
+			if(BEAUTY_LEVEL_BAD to BEAUTY_LEVEL_SCRUFFY)
+				add_event(null, "area_beauty", /datum/mood_event/shabbyroomsnob)
 				return
 	switch(A.beauty)
-		if(BEAUTY_LEVEL_BAD to BEAUTY_LEVEL_DECENT)
+		if(-INFINITY to BEAUTY_LEVEL_HORRID)
+			add_event(null, "area_beauty", /datum/mood_event/horridroom)
+		if(BEAUTY_LEVEL_HORRID to BEAUTY_LEVEL_BAD)
+			add_event(null, "area_beauty", /datum/mood_event/badroom)
+		if(BEAUTY_LEVEL_BAD to BEAUTY_LEVEL_SCRUFFY)
+			add_event(null, "area_beauty", /datum/mood_event/shabbyroom)
+		if(BEAUTY_LEVEL_SCRUFFY to BEAUTY_LEVEL_DECENT)
 			clear_event(null, "area_beauty")
 		if(BEAUTY_LEVEL_DECENT to BEAUTY_LEVEL_GOOD)
 			add_event(null, "area_beauty", /datum/mood_event/decentroom)
@@ -405,6 +429,7 @@
 			add_event(null, "area_beauty", /datum/mood_event/goodroom)
 		if(BEAUTY_LEVEL_GREAT to INFINITY)
 			add_event(null, "area_beauty", /datum/mood_event/greatroom)
+
 
 ///Called when parent is ahealed.
 /datum/component/mood/proc/on_revive(datum/source, full_heal)

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -213,7 +213,9 @@
 	// If the new amount would move towards the acceptable range faster then use it instead
 	if(amount < minimum)
 		amount += clamp(minimum - amount, 0, 0.7)
-	if((!override && HAS_TRAIT(parent, TRAIT_UNSTABLE)) || amount > maximum)
+	if(!override && HAS_TRAIT(parent, TRAIT_UNSTABLE) && amount > sanity)
+		amount = (sanity*9 + amount)/10 // Unstable greatly decrease senity regen instead of stopping it.
+	if(amount > maximum)
 		amount = min(sanity, amount)
 	var/mob/living/carbon/master = parent
 	if(amount == sanity) //Prevents stuff from flicking around.

--- a/code/datums/mood_events/beauty_events.dm
+++ b/code/datums/mood_events/beauty_events.dm
@@ -1,10 +1,26 @@
 /datum/mood_event/horridroom
 	description = "<span class='boldwarning'>This room looks terrible!</span>\n"
-	mood_change = -5
+	mood_change = -3
 
 /datum/mood_event/badroom
+	description = "<span class='warning'>This room looks quite bad.</span>\n"
+	mood_change = -2
+
+/datum/mood_event/shabbyroom
+	description = "<span class='warning'>This room looks a bit scruffy.</span>\n"
+	mood_change = -1
+
+/datum/mood_event/horridroomsnob
+	description = "<span class='boldwarning'>This room horrible!</span>\n"
+	mood_change = -6
+
+/datum/mood_event/badroomsnob
 	description = "<span class='warning'>This room looks really bad.</span>\n"
-	mood_change = -3
+	mood_change = -4
+
+/datum/mood_event/shabbyroomsnob
+	description = "<span class='warning'>This room looks scruffy.</span>\n"
+	mood_change = -2
 
 /datum/mood_event/decentroom
 	description = "<span class='nicegreen'>This room looks alright.</span>\n"

--- a/code/datums/mood_events/drink_events.dm
+++ b/code/datums/mood_events/drink_events.dm
@@ -1,28 +1,28 @@
 /datum/mood_event/drunk
-	mood_change = 3
+	mood_change = 2
 	description = "<span class='nicegreen'>Everything just feels better after a drink or two.</span>\n"
 
 /datum/mood_event/quality_nice
 	description = "<span class='nicegreen'>That drink wasn't bad at all.</span>\n"
 	mood_change = 2
-	timeout = 7 MINUTES
+	timeout = 9 MINUTES
 
 /datum/mood_event/quality_good
 	description = "<span class='nicegreen'>That drink was pretty good.</span>\n"
-	mood_change = 4
-	timeout = 7 MINUTES
+	mood_change = 3
+	timeout = 11 MINUTES
 
 /datum/mood_event/quality_verygood
 	description = "<span class='nicegreen'>That drink was great!</span>\n"
-	mood_change = 6
-	timeout = 7 MINUTES
+	mood_change = 4
+	timeout = 13 MINUTES
 
 /datum/mood_event/quality_fantastic
 	description = "<span class='nicegreen'>That drink was amazing!</span>\n"
-	mood_change = 8
-	timeout = 7 MINUTES
+	mood_change = 5
+	timeout = 15 MINUTES
 
 /datum/mood_event/amazingtaste
 	description = "<span class='nicegreen'>Amazing taste!</span>\n"
-	mood_change = 50
-	timeout = 10 MINUTES
+	mood_change = 15
+	timeout = 20 MINUTES

--- a/code/datums/mood_events/drug_events.dm
+++ b/code/datums/mood_events/drug_events.dm
@@ -1,16 +1,16 @@
 /datum/mood_event/high
-	mood_change = 6
+	mood_change = 4
 	description = "<span class='nicegreen'>Woooow duudeeeeee... I'm tripping baaalls...</span>\n"
 
 /datum/mood_event/smoked
 	description = "<span class='nicegreen'>I have had a smoke recently.</span>\n"
 	mood_change = 2
-	timeout = 6 MINUTES
+	timeout = 5 MINUTES
 
 /datum/mood_event/wrong_brand
 	description = "<span class='warning'>I hate that brand of cigarettes.</span>\n"
 	mood_change = -2
-	timeout = 6 MINUTES
+	timeout = 5 MINUTES
 
 /datum/mood_event/overdose
 	mood_change = -8
@@ -61,23 +61,23 @@
 
 /datum/mood_event/narcotic_medium
 	description = "<span class='nicegreen'>I feel comfortably numb.</span>\n"
-	mood_change = 4
-	timeout = 3 MINUTES
+	mood_change = 6
+	timeout = 1 MINUTES
 
 /datum/mood_event/narcotic_heavy
 	description = "<span class='nicegreen'>I feel like I'm wrapped up in cotton!</span>\n"
-	mood_change = 9
-	timeout = 3 MINUTES
+	mood_change = 12
+	timeout = 1 MINUTES
 
 /datum/mood_event/stimulant_medium
 	description = "<span class='nicegreen'>I have so much energy! I feel like I could do anything!</span>\n"
-	mood_change = 4
-	timeout = 3 MINUTES
+	mood_change = 6
+	timeout = 1 MINUTES
 
 /datum/mood_event/stimulant_heavy
 	description = "<span class='nicegreen'>Eh ah AAAAH! HA HA HA HA HAA! Uuuh.</span>\n"
-	mood_change = 6
-	timeout = 3 MINUTES
+	mood_change = 8
+	timeout = 1 MINUTES
 
 /datum/mood_event/nicotine_withdrawal_moderate
 	description = "<span class='warning'>Haven't had a smoke in a while. Feeling a little on edge... </span>\n"

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -338,3 +338,13 @@
 	description = "<span class='boldwarning'>MY PRECIOUS WINGS!!</span>\n"
 	mood_change = -10
 	timeout = 10 MINUTES
+
+/datum/mood_event/hardsuit_body
+	description = "<span class='warning'>Hardsuits are unconfortable.</span>\n"
+	mood_change = -1
+	timeout = 2 SECONDS
+
+/datum/mood_event/hardsuit_helmet
+	description = "<span class='warning'>I can't see anything with that helmet.</span>\n"
+	mood_change = -1
+	timeout = 2 SECONDS

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -137,14 +137,34 @@
 	mood_change = 12
 	timeout = 3 MINUTES
 
+/datum/mood_event/psy_comforted
+	description = "<span class='nicegreen'>Heard a soothing voice.</span>\n"
+	mood_change = 2
+	timeout = 5 MINUTES
+
 /datum/mood_event/religiously_comforted
+	description = "<span class='nicegreen'>I feel comforted by the presence of a holy person.</span>\n"
+	mood_change = 3
+	timeout = 5 MINUTES
+
+/datum/mood_event/clown_comforted
+	description = "<span class='nicegreen'>The clown is so funny.</span>\n"
+	mood_change = 4
+	timeout = 5 MINUTES
+
+/datum/mood_event/mime_comforted
+	description = "<span class='nicegreen'>Mimes are fun.</span>\n"
+	mood_change = 4
+	timeout = 5 MINUTES
+
+/datum/mood_event/chaplain_comforted
 	description = "<span class='nicegreen'>I feel comforted by the presence of a holy person.</span>\n"
 	mood_change = 3
 	timeout = 5 MINUTES
 
 /datum/mood_event/clownshoes
 	description = "<span class='nicegreen'>The shoes are a clown's legacy, I never want to take them off!</span>\n"
-	mood_change = 5
+	mood_change = 2
 
 /datum/mood_event/sacrifice_good
 	description ="<span class='nicegreen'>The gods are pleased with this offering!</span>\n"

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -1,12 +1,12 @@
 /datum/mood_event/hug
 	description = "<span class='nicegreen'>Hugs are nice.</span>\n"
-	mood_change = 1
+	mood_change = 2
 	timeout = 2 MINUTES
 
 /datum/mood_event/betterhug
 	description = "<span class='nicegreen'>Someone was very nice to me.</span>\n"
 	mood_change = 3
-	timeout = 4 MINUTES
+	timeout = 5 MINUTES
 
 /datum/mood_event/betterhug/add_effects(mob/friend)
 	description = "<span class='nicegreen'>[friend.name] was very nice to me.</span>\n"
@@ -14,20 +14,20 @@
 /datum/mood_event/besthug
 	description = "<span class='nicegreen'>Someone is great to be around, they make me feel so happy!</span>\n"
 	mood_change = 5
-	timeout = 4 MINUTES
+	timeout = 6 MINUTES
 
 /datum/mood_event/besthug/add_effects(mob/friend)
 	description = "<span class='nicegreen'>[friend.name] is great to be around, [friend.p_they()] makes me feel so happy!</span>\n"
 
 /datum/mood_event/warmhug
 	description = "<span class='nicegreen'>Warm cozy hugs are the best!</span>\n"
-	mood_change = 1
+	mood_change = 2
 	timeout = 2 MINUTES
 
 /datum/mood_event/arcade
 	description = "<span class='nicegreen'>I beat the arcade game!</span>\n"
 	mood_change = 3
-	timeout = 8 MINUTES
+	timeout = 10 MINUTES
 
 /datum/mood_event/blessing
 	description = "<span class='nicegreen'>I've been blessed.</span>\n"
@@ -36,18 +36,18 @@
 
 /datum/mood_event/book_nerd
 	description = "<span class='nicegreen'>I have recently read a book.</span>\n"
-	mood_change = 1
-	timeout = 5 MINUTES
+	mood_change = 2
+	timeout = 8 MINUTES
 
 /datum/mood_event/exercise
 	description = "<span class='nicegreen'>Working out releases those endorphins!</span>\n"
-	mood_change = 2
-	timeout = 5 MINUTES
+	mood_change = 3
+	timeout = 6 MINUTES
 
 /datum/mood_event/pet_animal
 	description = "<span class='nicegreen'>Animals are adorable! I can't stop petting them!</span>\n"
-	mood_change = 2
-	timeout = 5 MINUTES
+	mood_change = 3
+	timeout = 6 MINUTES
 
 /datum/mood_event/pet_animal/add_effects(mob/animal)
 	description = "<span class='nicegreen'>\The [animal.name] is adorable! I can't stop petting [animal.p_them()]!</span>\n"
@@ -55,14 +55,14 @@
 /datum/mood_event/honk
 	description = "<span class='nicegreen'>I've been honked!</span>\n"
 	mood_change = 2
-	timeout = 4 MINUTES
+	timeout = 5 MINUTES
 	special_screen_obj = "honked_nose"
 	special_screen_replace = FALSE
 
 /datum/mood_event/saved_life
 	description = "<span class='nicegreen'>It feels good to save a life.</span>\n"
-	mood_change = 6
-	timeout = 8 MINUTES
+	mood_change = 8
+	timeout = 5 MINUTES
 
 /datum/mood_event/oblivious
 	description = "<span class='nicegreen'>What a lovely day.</span>\n"
@@ -70,7 +70,7 @@
 
 /datum/mood_event/jolly
 	description = "<span class='nicegreen'>I feel happy for no particular reason.</span>\n"
-	mood_change = 6
+	mood_change = 4
 	timeout = 2 MINUTES
 
 /datum/mood_event/focused
@@ -98,12 +98,12 @@
 
 /datum/mood_event/cult
 	description = "<span class='nicegreen'>I have seen the truth, praise the almighty one!</span>\n"
-	mood_change = 10 //maybe being a cultist isn't that bad after all
+	mood_change = 5 //maybe being a cultist isn't that bad after all
 	hidden = TRUE
 
 /datum/mood_event/heretics
 	description = "<span class='nicegreen'>THE HIGHER I RISE, THE MORE I SEE.</span>\n"
-	mood_change = 10 //maybe being a cultist isnt that bad after all
+	mood_change = 8 //maybe being a cultist isnt that bad after all
 	hidden = TRUE
 
 /datum/mood_event/family_heirloom
@@ -222,7 +222,7 @@
 /datum/mood_event/aquarium_positive
 	description = "<span class='nicegreen'>Watching fish in an aquarium is calming.</span>\n"
 	mood_change = 3
-	timeout = 90 SECONDS
+	timeout = 5 MINUTES
 
 /datum/mood_event/gondola
 	description = "<span class='nicegreen'>I feel at peace and feel no need to make any sudden or rash actions.</span>\n"
@@ -231,7 +231,7 @@
 /datum/mood_event/kiss
 	description = "<span class='nicegreen'>Someone blew a kiss at me, I must be a real catch!</span>\n"
 	mood_change = 1.5
-	timeout = 2 MINUTES
+	timeout = 3 MINUTES
 
 /datum/mood_event/kiss/add_effects(mob/beau)
 	if(beau)

--- a/code/datums/mood_events/needs_events.dm
+++ b/code/datums/mood_events/needs_events.dm
@@ -1,15 +1,15 @@
 //nutrition
 /datum/mood_event/fat
 	description = "<span class='warning'><B>I'm so fat...</B></span>\n" //muh fatshaming
-	mood_change = -6
+	mood_change = -5
 
 /datum/mood_event/wellfed
 	description = "<span class='nicegreen'>I'm stuffed!</span>\n"
-	mood_change = 8
+	mood_change = 4
 
 /datum/mood_event/fed
 	description = "<span class='nicegreen'>I have recently had some food.</span>\n"
-	mood_change = 5
+	mood_change = 2
 
 /datum/mood_event/hungry
 	description = "<span class='warning'>I'm getting a bit hungry.</span>\n"
@@ -53,6 +53,10 @@
 	description = "<span class='boldwarning'>Oh god, that's disgusting...</span>\n"
 	mood_change = -8
 
+/datum/mood_event/disgust/unpleasant_smell
+	description = "<span class='warning'>I can smell something unpleasant.</span>\n"
+	mood_change = -2
+
 /datum/mood_event/disgust/bad_smell
 	description = "<span class='warning'>I can smell something horribly decayed inside this room.</span>\n"
 	mood_change = -6
@@ -85,9 +89,9 @@
 /datum/mood_event/nice_shower
 	description = "<span class='nicegreen'>I have recently had a nice shower.</span>\n"
 	mood_change = 4
-	timeout = 5 MINUTES
+	timeout = 7 MINUTES
 
 /datum/mood_event/fresh_laundry
 	description = "<span class='nicegreen'>There's nothing like the feeling of a freshly laundered jumpsuit.</span>\n"
-	mood_change = 2
+	mood_change = 3
 	timeout = 10 MINUTES

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -382,6 +382,15 @@
 	medical_record_text = "Patient presents a notably unassertive personality and is easy to manipulate."
 	hardcore_value = 4
 
+/datum/quirk/snob
+	name = "Snob"
+	desc = "You care about the finer things, if a room doesn't look nice its just not really worth it, is it?"
+	value = -1
+	gain_text = "<span class='notice'>You feel like you understand what things should look like.</span>"
+	lose_text = "<span class='notice'>Well who cares about deco anyways?</span>"
+	medical_record_text = "Patient seems to be rather stuck up."
+	mob_trait = TRAIT_SNOB
+
 /datum/quirk/insanity
 	name = "Reality Dissociation Syndrome"
 	desc = "You suffer from a severe disorder that causes very vivid hallucinations. Mindbreaker toxin can suppress its effects, and you are immune to mindbreaker's hallucinogenic properties. <b>This is not a license to grief.</b>"

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -612,12 +612,12 @@
 
 /datum/quirk/unstable
 	name = "Unstable"
-	desc = "Due to past troubles, you are unable to recover your sanity if you lose it. Be very careful managing your mood!"
+	desc = "Due to past troubles, you very slowly recover your sanity if you lose it. Be very careful managing your mood!"
 	value = -10
 	mob_trait = TRAIT_UNSTABLE
 	gain_text = "<span class='danger'>There's a lot on your mind right now.</span>"
 	lose_text = "<span class='notice'>Your mind finally feels calm.</span>"
-	medical_record_text = "Patient's mind is in a vulnerable state, and cannot recover from traumatic events."
+	medical_record_text = "Patient's mind is in a vulnerable state, and need time to recover from traumatic events."
 	hardcore_value = 9
 
 /datum/quirk/allergic

--- a/code/datums/quirks/neutral.dm
+++ b/code/datums/quirks/neutral.dm
@@ -71,15 +71,6 @@
 		if(!initial(species.disliked_food) & MEAT)
 			species.disliked_food &= ~MEAT
 
-/datum/quirk/snob
-	name = "Snob"
-	desc = "You care about the finer things, if a room doesn't look nice its just not really worth it, is it?"
-	value = 0
-	gain_text = "<span class='notice'>You feel like you understand what things should look like.</span>"
-	lose_text = "<span class='notice'>Well who cares about deco anyways?</span>"
-	medical_record_text = "Patient seems to be rather stuck up."
-	mob_trait = TRAIT_SNOB
-
 /datum/quirk/pineapple_liker
 	name = "Ananas Affinity"
 	desc = "You find yourself greatly enjoying fruits of the ananas genus. You can't seem to ever get enough of their sweet goodness!"

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -29,7 +29,7 @@
 	/// Beauty average per open turf in the area
 	var/beauty = 0
 	/// If a room is too big it doesn't have beauty.
-	var/beauty_threshold = 150
+	var/beauty_threshold = 450
 
 	/// For space, the asteroid, lavaland, etc. Used with blueprints or with weather to determine if we are adding a new area (vs editing a station room)
 	var/outdoors = FALSE

--- a/code/game/area/space_station_13_areas.dm
+++ b/code/game/area/space_station_13_areas.dm
@@ -650,6 +650,8 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 /area/service/cafeteria
 	name = "Cafeteria"
+	mood_bonus = 2
+	mood_message = "<span class='nicegreen'>I like being in the cafeteria!</span>\n"
 	icon_state = "cafeteria"
 
 /area/service/kitchen
@@ -667,7 +669,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/service/bar
 	name = "Bar"
 	icon_state = "bar"
-	mood_bonus = 5
+	mood_bonus = 3
 	mood_message = "<span class='nicegreen'>I love being in the bar!</span>\n"
 	mood_trait = TRAIT_EXTROVERT
 	airlock_wires = /datum/wires/airlock/service
@@ -680,6 +682,8 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/service/bar/atrium
 	name = "Atrium"
 	icon_state = "bar"
+	mood_bonus = 2
+	mood_message = "<span class='nicegreen'>I like being in the atrium!</span>\n"
 	sound_environment = SOUND_AREA_WOODFLOOR
 
 /area/service/electronic_marketing_den
@@ -705,7 +709,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/service/library
 	name = "Library"
 	icon_state = "library"
-	mood_bonus = 5
+	mood_bonus = 3
 	mood_message = "<span class='nicegreen'>I love being in the library!</span>\n"
 	mood_trait = TRAIT_INTROVERT
 	area_flags = CULT_PERMITTED | BLOBS_ALLOWED | UNIQUE_AREA
@@ -738,7 +742,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 /area/service/chapel
 	icon_state = "chapel"
-	mood_bonus = 5
+	mood_bonus = 3
 	mood_message = "<span class='nicegreen'>Being in the chapel brings me peace.</span>\n"
 	mood_trait = TRAIT_SPIRITUAL
 	ambience_index = AMBIENCE_HOLY
@@ -1091,7 +1095,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/medical/psychology
 	name = "Psychology Office"
 	icon_state = "psychology"
-	mood_bonus = 3
+	mood_bonus = 5
 	mood_message = "<span class='nicegreen'>I feel at ease here.</span>\n"
 	ambientsounds = list('sound/ambience/aurora_caelus_short.ogg')
 

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -5,7 +5,7 @@
 	var/blood_state = "" //I'm sorry but cleanable/blood code is ass, and so is blood_DNA
 	var/bloodiness = 0 //0-100, amount of blood in this decal, used for making footprints and affecting the alpha of bloody footprints
 	var/mergeable_decal = TRUE //when two of these are on a same tile or do we need to merge them into just one?
-	var/beauty = 0
+	var/beauty = -25
 	///The type of cleaning required to clean the decal, CLEAN_TYPE_LIGHT_DECAL can be cleaned with mops and soap, CLEAN_TYPE_HARD_DECAL can be cleaned by soap, see __DEFINES/cleaning.dm for the others
 	var/clean_type = CLEAN_TYPE_LIGHT_DECAL
 

--- a/code/game/objects/effects/decals/cleanable/aliens.dm
+++ b/code/game/objects/effects/decals/cleanable/aliens.dm
@@ -8,7 +8,7 @@
 	random_icon_states = list("xfloor1", "xfloor2", "xfloor3", "xfloor4", "xfloor5", "xfloor6", "xfloor7")
 	bloodiness = BLOOD_AMOUNT_PER_DECAL
 	blood_state = BLOOD_STATE_XENO
-	beauty = -250
+	beauty = -350
 	clean_type = CLEAN_TYPE_BLOOD
 
 /obj/effect/decal/cleanable/xenoblood/Initialize()

--- a/code/game/objects/effects/decals/cleanable/food.dm
+++ b/code/game/objects/effects/decals/cleanable/food.dm
@@ -2,7 +2,7 @@
 /obj/effect/decal/cleanable/food
 	icon = 'icons/effects/tomatodecal.dmi'
 	gender = NEUTER
-	beauty = -100
+	beauty = -200
 
 /obj/effect/decal/cleanable/food/tomato_smudge
 	name = "tomato smudge"

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -6,7 +6,7 @@
 	random_icon_states = list("floor1", "floor2", "floor3", "floor4", "floor5", "floor6", "floor7")
 	blood_state = BLOOD_STATE_HUMAN
 	bloodiness = BLOOD_AMOUNT_PER_DECAL
-	beauty = -100
+	beauty = -400
 	clean_type = CLEAN_TYPE_BLOOD
 	var/dryname = "dried blood" //when the blood lasts long enough, it becomes dry and gets a new name
 	var/drydesc = "Looks like it's been here a while. Eew." //as above
@@ -67,7 +67,7 @@
 	icon_state = "tracks"
 	desc = "They look like tracks left by wheels."
 	random_icon_states = null
-	beauty = -50
+	beauty = -75
 	dryname = "dried tracks"
 	drydesc = "Some old bloody tracks left by wheels. Machines are evil, perhaps."
 
@@ -75,7 +75,7 @@
 	name = "blood"
 	icon = 'icons/effects/blood.dmi'
 	desc = "Your instincts say you shouldn't be following these."
-	beauty = -50
+	beauty = -75
 	var/list/existing_dirs = list()
 
 /obj/effect/decal/cleanable/trail_holder/can_bloodcrawl_in()

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -3,7 +3,7 @@
 	desc = "Someone should clean that up."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "shards"
-	beauty = -50
+	beauty = -75
 
 /obj/effect/decal/cleanable/ash
 	name = "ashes"
@@ -11,7 +11,7 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "ash"
 	mergeable_decal = FALSE
-	beauty = -50
+	beauty = -75
 
 /obj/effect/decal/cleanable/ash/Initialize()
 	. = ..()
@@ -26,7 +26,7 @@
 /obj/effect/decal/cleanable/ash/large
 	name = "large pile of ashes"
 	icon_state = "big_ash"
-	beauty = -100
+	beauty = -150
 
 /obj/effect/decal/cleanable/ash/large/Initialize()
 	. = ..()
@@ -37,7 +37,7 @@
 	desc = "Back to sand."
 	icon = 'icons/obj/shards.dmi'
 	icon_state = "tiny"
-	beauty = -100
+	beauty = -175
 
 /obj/effect/decal/cleanable/glass/Initialize()
 	. = ..()
@@ -59,7 +59,7 @@
 	smoothing_groups = list(SMOOTH_GROUP_CLEANABLE_DIRT)
 	canSmoothWith = list(SMOOTH_GROUP_CLEANABLE_DIRT, SMOOTH_GROUP_WALLS)
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	beauty = -75
+	beauty = -125
 
 /obj/effect/decal/cleanable/dirt/Initialize()
 	. = ..()
@@ -120,13 +120,13 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "molten"
 	mergeable_decal = FALSE
-	beauty = -150
+	beauty = -200
 	clean_type = CLEAN_TYPE_HARD_DECAL
 
 /obj/effect/decal/cleanable/molten_object/large
 	name = "big gooey grey mass"
 	icon_state = "big_molten"
-	beauty = -300
+	beauty = -350
 
 //Vomit (sorry)
 /obj/effect/decal/cleanable/vomit
@@ -135,7 +135,7 @@
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "vomit_1"
 	random_icon_states = list("vomit_1", "vomit_2", "vomit_3", "vomit_4")
-	beauty = -150
+	beauty = -250
 
 /obj/effect/decal/cleanable/vomit/attack_hand(mob/user, list/modifiers)
 	. = ..()
@@ -170,6 +170,7 @@
 	name = "chemical pile"
 	desc = "A pile of chemicals. You can't quite tell what's inside it."
 	gender = NEUTER
+	beauty = -25
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "ash"
 
@@ -177,6 +178,7 @@
 	name = "shreds"
 	desc = "The shredded remains of what appears to be clothing."
 	icon_state = "shreds"
+	beauty = -25
 	gender = PLURAL
 	mergeable_decal = FALSE
 
@@ -197,6 +199,7 @@
 	icon = 'icons/effects/atmospherics.dmi'
 	icon_state = "plasma_old"
 	gender = NEUTER
+	beauty = -25
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /obj/effect/decal/cleanable/glitter/pink
@@ -215,6 +218,7 @@
 	name = "stabilized plasma"
 	desc = "A puddle of stabilized plasma."
 	icon_state = "flour"
+	beauty = -25
 	icon = 'icons/effects/tomatodecal.dmi'
 	color = "#2D2D2D"
 
@@ -223,6 +227,7 @@
 	desc = "One bug squashed. Four more will rise in its place."
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "xfloor1"
+	beauty = -50
 	random_icon_states = list("xfloor1", "xfloor2", "xfloor3", "xfloor4", "xfloor5", "xfloor6", "xfloor7")
 
 /obj/effect/decal/cleanable/confetti
@@ -230,6 +235,7 @@
 	desc = "Tiny bits of colored paper thrown about for the janitor to enjoy!"
 	icon = 'icons/effects/confetti_and_decor.dmi'
 	icon_state = "confetti"
+	beauty = -25
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT //the confetti itself might be annoying enough
 
 /obj/effect/decal/cleanable/plastic
@@ -237,12 +243,14 @@
 	desc = "Bits of torn, broken, worthless plastic."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "shards"
+	beauty = -25
 	color = "#c6f4ff"
 
 /obj/effect/decal/cleanable/wrapping
 	name = "wrapping shreds"
 	desc = "Torn pieces of cardboard and paper, left over from a package."
 	icon = 'icons/obj/objects.dmi'
+	beauty = -25
 	icon_state = "paper_shreds"
 
 /obj/effect/decal/cleanable/garbage
@@ -251,7 +259,7 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "garbage"
 	layer = OBJ_LAYER //To display the decal over wires.
-	beauty = -150
+	beauty = -200
 	clean_type = CLEAN_TYPE_HARD_DECAL
 
 /obj/effect/decal/cleanable/garbage/Initialize()

--- a/code/game/objects/effects/decals/cleanable/robots.dm
+++ b/code/game/objects/effects/decals/cleanable/robots.dm
@@ -10,7 +10,7 @@
 	blood_state = BLOOD_STATE_OIL
 	bloodiness = BLOOD_AMOUNT_PER_DECAL
 	mergeable_decal = FALSE
-	beauty = -50
+	beauty = -75
 	clean_type = CLEAN_TYPE_BLOOD
 
 /obj/effect/decal/cleanable/robot_debris/Initialize()
@@ -67,7 +67,7 @@
 	random_icon_states = list("floor1", "floor2", "floor3", "floor4", "floor5", "floor6", "floor7")
 	blood_state = BLOOD_STATE_OIL
 	bloodiness = BLOOD_AMOUNT_PER_DECAL
-	beauty = -100
+	beauty = -150
 	clean_type = CLEAN_TYPE_BLOOD
 
 /obj/effect/decal/cleanable/oil/Initialize()
@@ -94,7 +94,7 @@
 /obj/effect/decal/cleanable/oil/streak
 	icon_state = "streak1"
 	random_icon_states = list("streak1", "streak2", "streak3", "streak4", "streak5")
-	beauty = -50
+	beauty = -75
 
 /obj/effect/decal/cleanable/oil/slippery/ComponentInitialize()
 	. = ..()

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -79,6 +79,7 @@
 	current_tick_amount += amount
 
 /obj/item/clothing/head/helmet/space/hardsuit/process(delta_time)
+	SEND_SIGNAL(loc, COMSIG_ADD_MOOD_EVENT, "hardsuit_helmet", /datum/mood_event/hardsuit_helmet)
 	radiation_count = LPFILTER(radiation_count, current_tick_amount, delta_time, RAD_GEIGER_RC)
 
 	if(current_tick_amount)
@@ -170,6 +171,10 @@
 			to_chat(user, "<span class='notice'>You have successfully repaired [src]'s helmet.</span>")
 			new /obj/item/light/bulb/broken(drop_location())
 	return ..()
+
+/obj/item/clothing/suit/space/hardsuit/process()
+	. = ..()
+	SEND_SIGNAL(loc, COMSIG_ADD_MOOD_EVENT, "hardsuit_body", /datum/mood_event/hardsuit_body)
 
 /obj/item/clothing/suit/space/hardsuit/equipped(mob/user, slot)
 	..()
@@ -802,6 +807,7 @@
 			owner.update_inv_wear_suit()
 		return TRUE
 	return FALSE
+
 
 /obj/item/clothing/suit/space/hardsuit/shielded/process()
 	. = ..()

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -131,7 +131,7 @@
 		/obj/item/camera/spooky = 1
 		)
 
-	skillchips = list(/obj/item/skillchip/entrails_reader)
+	skillchips = list(/obj/item/skillchip/entrails_reader, /obj/item/skillchip/chaplain_plasm)
 
 	backpack = /obj/item/storage/backpack/cultpack
 	satchel = /obj/item/storage/backpack/cultpack

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -46,6 +46,8 @@
 	backpack = /obj/item/storage/backpack/clown
 	satchel = /obj/item/storage/backpack/clown
 	duffelbag = /obj/item/storage/backpack/duffelbag/clown //strangely has a duffel
+	
+	skillchips = list(/obj/item/skillchip/clown_joke)
 
 	box = /obj/item/storage/box/hug/survival
 

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -40,6 +40,8 @@
 
 	backpack = /obj/item/storage/backpack/mime
 	satchel = /obj/item/storage/backpack/mime
+	
+	skillchips = list(/obj/item/skillchip/mime_grace)
 
 	chameleon_extras = /obj/item/stamp/mime
 

--- a/code/modules/jobs/job_types/psychologist.dm
+++ b/code/modules/jobs/job_types/psychologist.dm
@@ -34,7 +34,7 @@
 
 	backpack_contents = list(/obj/item/storage/pill_bottle/mannitol, /obj/item/storage/pill_bottle/psicodine, /obj/item/storage/pill_bottle/paxpsych, /obj/item/storage/pill_bottle/happinesspsych, /obj/item/storage/pill_bottle/lsdpsych)
 
-	skillchips = list(/obj/item/skillchip/job/psychology)
+	skillchips = list(/obj/item/skillchip/job/psychology, /obj/item/skillchip/psy_ramble)
 
 	backpack = /obj/item/storage/backpack/medic
 	satchel = /obj/item/storage/backpack/satchel/med

--- a/code/modules/library/skill_learning/skillchip.dm
+++ b/code/modules/library/skill_learning/skillchip.dm
@@ -457,3 +457,118 @@
 	skill_icon = "hand-holding"
 	activate_message = "<span class='notice'>Carrying people across your back feels like second nature to you.</span>"
 	deactivate_message = "<span class='notice'>Your expert knowledge in fireman carrying fades from your mind.</span>"
+
+/obj/item/skillchip/clown_joke
+	name = "FUN skillchip"
+	skill_name = "FUN"
+	chip_category = SKILLCHIP_CATEGORY_FUN_VOICE
+	incompatibility_list = list(SKILLCHIP_CATEGORY_FUN_VOICE)
+	skill_description = "Learn how to make great jokes!"
+	activate_message = "<span class='notice'>Your feel like you are ready to bring the fun to the crew.</span>"
+	deactivate_message = "<span class='notice'>Your pun expertise fades from your mind.</span>"
+
+/obj/item/skillchip/clown_joke/proc/handle_speech(datum/source, list/speech_args)
+	var/mob/living/carbon/user = holding_brain.owner
+	if (iscarbon(user))
+		var/list/candidates = get_hearers_in_view(6, user) - user
+
+		for(var/mob/living/candidate in candidates)
+			if(candidate.stat != DEAD && candidate.can_hear())
+				SEND_SIGNAL(candidate, COMSIG_ADD_MOOD_EVENT, "fun_speech", /datum/mood_event/clown_comforted)
+
+
+/obj/item/skillchip/clown_joke/on_activate(mob/living/carbon/user, silent=FALSE)
+	.=..(user, silent)
+	RegisterSignal(user, COMSIG_MOB_SAY, .proc/handle_speech)
+
+
+/obj/item/skillchip/clown_joke/on_deactivate(mob/living/carbon/user, silent=FALSE)
+	.=..(user, silent)
+	UnregisterSignal(user, COMSIG_MOB_SAY)
+
+
+/obj/item/skillchip/chaplain_plasm
+	name = "PROZ3LYT1Z3 skillchip"
+	skill_name = "PROZ3LYT1Z3"
+	chip_category = SKILLCHIP_CATEGORY_FUN_VOICE
+	incompatibility_list = list(SKILLCHIP_CATEGORY_FUN_VOICE)
+	skill_description = "Learn how to preach for hours!"
+	activate_message = "<span class='notice'>Your feel like you are ready to convert the crew.</span>"
+	deactivate_message = "<span class='notice'>Your voice techniques fades from your mind.</span>"
+
+/obj/item/skillchip/chaplain_plasm/proc/handle_speech(datum/source, list/speech_args)
+	var/mob/living/carbon/user = holding_brain.owner
+	if (iscarbon(user))
+		var/list/candidates = get_hearers_in_view(6, user) - user
+
+		for(var/mob/living/candidate in candidates)
+			if(candidate.stat != DEAD && candidate.can_hear())
+				SEND_SIGNAL(candidate, COMSIG_ADD_MOOD_EVENT, "fun_speech", /datum/mood_event/chaplain_comforted)
+
+
+/obj/item/skillchip/chaplain_plasm/on_activate(mob/living/carbon/user, silent=FALSE)
+	.=..(user, silent)
+	RegisterSignal(user, COMSIG_MOB_SAY, .proc/handle_speech)
+
+
+/obj/item/skillchip/chaplain_plasm/on_deactivate(mob/living/carbon/user, silent=FALSE)
+	.=..(user, silent)
+	UnregisterSignal(user, COMSIG_MOB_SAY)
+
+
+/obj/item/skillchip/psy_ramble
+	name = "1SAN1TY skillchip"
+	skill_name = "1SAN1TY"
+	chip_category = SKILLCHIP_CATEGORY_FUN_VOICE
+	incompatibility_list = list(SKILLCHIP_CATEGORY_FUN_VOICE)
+	skill_description = "Learn to talk with a soothing voice!"
+	activate_message = "<span class='notice'>Your feel like you are ready to calm the crew.</span>"
+	deactivate_message = "<span class='notice'>Your calming techniques fades from your mind.</span>"
+
+/obj/item/skillchip/psy_ramble/proc/handle_speech(datum/source, list/speech_args)
+	var/mob/living/carbon/user = holding_brain.owner
+	if (iscarbon(user))
+		var/list/candidates = get_hearers_in_view(6, user) - user
+
+		for(var/mob/living/candidate in candidates)
+			if(candidate.stat != DEAD && candidate.can_hear())
+				SEND_SIGNAL(candidate, COMSIG_ADD_MOOD_EVENT, "fun_speech", /datum/mood_event/psy_comforted)
+				candidate.adjustOrganLoss(ORGAN_SLOT_BRAIN, -4)
+
+
+/obj/item/skillchip/psy_ramble/on_activate(mob/living/carbon/user, silent=FALSE)
+	.=..(user, silent)
+	RegisterSignal(user, COMSIG_MOB_SAY, .proc/handle_speech)
+
+
+/obj/item/skillchip/psy_ramble/on_deactivate(mob/living/carbon/user, silent=FALSE)
+	.=..(user, silent)
+	UnregisterSignal(user, COMSIG_MOB_SAY)
+
+/obj/item/skillchip/mime_grace
+	name = "M1M3 GRAC3 skillchip"
+	skill_name = "M1M3 GRAC3"
+	chip_category = SKILLCHIP_CATEGORY_FUN_VOICE
+	incompatibility_list = list(SKILLCHIP_CATEGORY_FUN_VOICE)
+	skill_description = "Learn to mime with grace!"
+	activate_message = "<span class='notice'>Your feel like you are took acting classes.</span>"
+	deactivate_message = "<span class='notice'>Your acting skils fade.</span>"
+
+/obj/item/skillchip/mime_grace/proc/handle_emote(datum/source, list/speech_args)
+	var/mob/living/carbon/user = holding_brain.owner
+	if (iscarbon(user))
+		var/list/candidates = oview(6, user) - user
+
+		for(var/mob/living/candidate in candidates)
+			if(candidate.stat != DEAD && !candidate.is_blind())
+				SEND_SIGNAL(candidate, COMSIG_ADD_MOOD_EVENT, "fun_speech", /datum/mood_event/mime_comforted)
+
+
+/obj/item/skillchip/mime_grace/on_activate(mob/living/carbon/user, silent=FALSE)
+	.=..(user, silent)
+	RegisterSignal(user, COMSIG_MOB_EMOTE, .proc/handle_emote)
+
+
+/obj/item/skillchip/mime_grace/on_deactivate(mob/living/carbon/user, silent=FALSE)
+	.=..(user, silent)
+	UnregisterSignal(user, COMSIG_MOB_EMOTE)

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -12,7 +12,7 @@
 	attack_verb_simple = list("attack", "slap", "whack")
 
 	///The brain's organ variables are significantly more different than the other organs, with half the decay rate for balance reasons, and twice the maxHealth
-	decay_factor = STANDARD_ORGAN_DECAY * 0.5 //30 minutes of decaying to result in a fully damaged brain, since a fast decay rate would be unfun gameplay-wise
+	decay_factor = STANDARD_ORGAN_DECAY * 0.45 //30 minutes of decaying to result in a fully damaged brain, since a fast decay rate would be unfun gameplay-wise
 
 	maxHealth = BRAIN_DAMAGE_DEATH
 	low_threshold = 45

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -396,6 +396,7 @@
 					SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "smell")
 					if(prob(5))
 						to_chat(owner, "<span class='notice'>There is an unpleasant smell in the air.</span>")
+						SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "smell", /datum/mood_event/disgust/unpleasant_smell)
 				if(5 to 15)
 					//At somewhat higher pp, warning becomes more obvious
 					if(prob(15))


### PR DESCRIPTION
TLDR des objectifs : 
- augmente l'importance du moral et de la sanité (bas niveau  de sanité causent des brain trauma)
- boost psy, chapelin, clown.mime, barman et drogues pour les rendre utile
- Augmenter l'importance de la propreté
- Bas niveau de sanité cause des brain trauma.

Overview : 
**Moral, Brain damage et trauma** 
- La sanité varie de manière plus progressive selon le moral (ainsi les boosts/malus mineurs ont un effet).
- Les bas niveaux de sanité causent des brain damages. Ils sont capés (pour pas tuer les gens ou faire qu'ils soient brain dead trop vite après la mort), et augmentent a bas niveau de sanité.
- Ces brain damages peuvent causer un/des traumas (seul le plus bas niveau de sanité peut endommager le cerveau sufisament pour causer des trauma sévères) [le peut est quand meme très probable a très bas niveau de sanité].
- La vitesse de decay des cerveaux est réduite de 10% étant donné que cette modif augment les chance d'avoir des brain trauma lors de la mort.


**Beauté des pièces**
- Fix et rebalance le système de beauté des pièces (qui impacte ensuite le moral). 
_Todo : Prendre en compte le type de sol pour la beauté de la piece._
- Les pièces mochent réduisent le moral de tous au lieu de seulement les TRAIT_SNOB
- Le TRAIT_SNOBaugmente l'impact sur le moral.
- Les dechets et traces de sang impacte fortement la beauté des pièce.



**Bonus des pièces**

- boost/nerf : reduction des boost du bar/chappelle/biblio de 5 à 3 mais actif pour tous.
- boost de la psychologie : passage de 3 à 5.
- nerf de la cafeteria : passage de 5 à 2 mais actif pour tous.
- boost/nerf : mood trait : (introvert, extrovert, religieux) : au lieu d'activer l'effet ça double (passe à 8 pour la zone en question).


**Nouritures, boissons et drogues**

- nerf : gain de moral de fed et well_fed  (5/7 -> 2/4) [aucun changement pour les "nouritures aimées", juste l'effet passif d'avoir bien mangé]
- boost : nerf malus fat : -6 -> -5
- boost : nice_shower, fresh_laundry, book_nerd, exercise, pet_animal, honk, aquarium_positive
boost/nerf : forte augmentation de la durée du boost de moral des boissons, légère reduction de leur boost.(offre un long boost de moral maintenant).
boost/nerf : augmentation de l'eefet du boost de moral des drogues, légère reduction de leur durée (offre un court boost de moral maintenant mai sarrète très vite après la fin de la consomation de la drogue). Pas la nicotine.
TLDR  : objectif devoir gagner du moral autrement qu'en mangeant et perdre de moral seulement en mourrant de fain.

**Skillchip metier**
- clown: Boost moral +4 pour 5 min quand parle
- mime: Boost moral +4 pour 5 min quand mime
- chapelin : Boost moral +3 pour 5 min quand parle
- psy : Boost moral +2 pour 5 min quand parle et soigne 4 brain dmg
todo : soigner les trauma en psy ?

**Autre**
- boost : hug, betterhug, besthug  (seulement pour celui qui reçoit le hug. Considerez le trait friendly en jouant un psy/prètre pour donner de meilleurs hugs) (commandez des animaux en psy)
- nerf : jolly 6 -> 4
- boost : focused (le trai de moral des antags) 4 -> 5
- nerf : cult  10 -> 5
- nerf : heretics 10 -> 8
- nerf : hardsuit : -1 pour le corp, -1 pour le casque de moral.

