### PR TITLE
Nightmare rebalance

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -22,11 +22,13 @@
 	var/turf/T = H.loc
 	if(istype(T))
 		var/light_amount = T.get_lumcount()
-
-		if(light_amount > SHADOW_SPECIES_LIGHT_THRESHOLD) //if there's enough light, start dying
-			H.take_overall_damage(0.5 * delta_time, 0.5 * delta_time, 0, BODYPART_ORGANIC)
-		else if (light_amount < SHADOW_SPECIES_LIGHT_THRESHOLD) //heal in the dark
-			H.heal_overall_damage(0.5 * delta_time, 0.5 * delta_time, 0, BODYPART_ORGANIC)
+		if(IS_OPAQUE_TURF(T))
+			H.take_overall_damage(0.15 * delta_time, 0.45 * delta_time, 0, BODYPART_ORGANIC)
+		else
+			if(light_amount > SHADOW_SPECIES_LIGHT_THRESHOLD) //if there's enough light, start dying
+				H.take_overall_damage(0.2 * delta_time, 0.6 * delta_time, 0, BODYPART_ORGANIC)
+			else if (light_amount < SHADOW_SPECIES_LIGHT_THRESHOLD) //heal in the dark
+				H.heal_overall_damage(0.5 * delta_time, 1.2 * delta_time, 0, BODYPART_ORGANIC)
 
 /datum/species/shadow/check_roundstart_eligible()
 	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])


### PR DESCRIPTION
- Reduire legerement la vitesse a laquelle ils prennent des dmgs de la lumiere (0.5 brute, 0.5 burn -> 0.2 brut, 0.6 burn)
- Augmenter leur vitesse de regen des burn :  0.5 brut/0.5 burn -> 0.5 brut/1.2 burn
- Peut maintenanant toujours shadow vault dans les murs/porte opaque (même si lumière proche du mur).
- Prend des dmgs dans les murs/portes opaques (meme en vault) : 0.15 brute/0.45 burn
- Prend 15 dmgs brut lors d'un decloack volontaire dans un mur opaque.
