### PR TITLE
Alien lowpop rebalance

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -75,7 +75,7 @@
 					blocked = TRUE
 			if(!blocked)
 				L.visible_message(span_danger("[src] pounces on [L]!"), span_userdanger("[src] pounces on you!"))
-				L.Paralyze(100)
+				L.Paralyze(80)
 				sleep(2)//Runtime prevention (infinite bump() calls on hulks)
 				step_towards(src,L)
 			else

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/praetorian.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/praetorian.dm
@@ -1,8 +1,8 @@
 /mob/living/carbon/alien/humanoid/royal/praetorian
 	name = "alien praetorian"
 	caste = "p"
-	maxHealth = 250
-	health = 250
+	maxHealth = 220
+	health = 220
 	icon_state = "alienp"
 
 /mob/living/carbon/alien/humanoid/royal/praetorian/Initialize(mapload)

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -23,8 +23,8 @@
 /mob/living/carbon/alien/humanoid/royal/queen
 	name = "alien queen"
 	caste = "q"
-	maxHealth = 400
-	health = 400
+	maxHealth = 300
+	health = 300
 	icon_state = "alienq"
 	var/datum/action/small_sprite/smallsprite = new/datum/action/small_sprite/queen()
 

--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -40,9 +40,9 @@
 	/// The maximum plasma this organ can store.
 	var/max_plasma = 250
 	/// The rate this organ regenerates its owners health at per damage type per second.
-	var/heal_rate = 2.5
+	var/heal_rate = 2
 	/// The rate this organ regenerates plasma at per second.
-	var/plasma_rate = 5
+	var/plasma_rate = 4
 
 /obj/item/organ/alien/plasmavessel/large
 	name = "large plasma vessel"
@@ -50,10 +50,10 @@
 	w_class = WEIGHT_CLASS_BULKY
 	storedPlasma = 200
 	max_plasma = 500
-	plasma_rate = 7.5
+	plasma_rate = 5
 
 /obj/item/organ/alien/plasmavessel/large/queen
-	plasma_rate = 10
+	plasma_rate = 6
 
 /obj/item/organ/alien/plasmavessel/small
 	name = "small plasma vessel"
@@ -61,7 +61,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	storedPlasma = 100
 	max_plasma = 150
-	plasma_rate = 2.5
+	plasma_rate = 2
 
 /obj/item/organ/alien/plasmavessel/small/tiny
 	name = "tiny plasma vessel"

--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -4,7 +4,7 @@
 	damage = 5
 	damage_type = TOX
 	nodamage = FALSE
-	paralyze = 100
+	paralyze = 70
 	flag = BIO
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/neurotoxin
 

--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -301,11 +301,11 @@
 	name = "Tail Sweep"
 	desc = "Throw back attackers with a sweep of your tail."
 	sound = 'sound/magic/tail_swing.ogg'
-	charge_max = 150
+	charge_max = 300
 	clothes_req = FALSE
 	antimagic_allowed = TRUE
 	range = 2
-	cooldown_min = 150
+	cooldown_min = 300
 	invocation_type = "none"
 	sparkle_path = /obj/effect/temp_visual/dir_setting/tailsweep
 	action_icon = 'icons/mob/actions/actions_xeno.dmi'
@@ -318,7 +318,7 @@
 		var/mob/living/carbon/C = user
 		playsound(C.loc, 'sound/voice/hiss5.ogg', 80, TRUE, TRUE)
 		C.spin(6,1)
-	..(targets, user, 60)
+	..(targets, user, 30)
 
 /obj/effect/proc_holder/spell/targeted/sacred_flame
 	name = "Sacred Flame"


### PR DESCRIPTION
Nerf principalement la reine et le preatorien qui ont étés conçus pour pouvoir gagner des combats vs 3-5 enemis  simultanément sur un serveur highpop.
Réduit légèrement leur vitesse de regen du plasma/vie, laissant légèrement plus de temps a l'équipage pour se réorganiser entre deux combats et à se préparer après que le premier alien arrive sur la station.
Réduit l'efficacité de leur stuns/imobilise qui sont extrêmement efficaces en low pop, en particulier le tail sweep de la reine.

Note : max health ne compte pas les 100 health de crit.
Aliens :
- reine : -25% max health (400->300), -40% plasma regen, -20% health regen
- preatorien : -12 % max health(250->220), -33% plasma regen, -20% health regen
- others aliens : -20% plasma regen, -20% health regen

Abilités :
- Tail sweep : cooldown +100% (15s->30s), Paralyse -40%(8s -> 5s)
- Neurotox spit (queen/pretorian/sentinel): -25% Paralyse : 12s -> 9s
- Lunge (hunter) : -20% Paralyse : 12s -> 10s
