### PR TITLE
Boost heretic:

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -147,10 +147,10 @@
 	forge_objective(pck1,assasination,protection)
 	forge_objective(pck2,assasination,protection)
 
-	var/datum/objective/sacrifice_ecult/sac_objective = new
-	sac_objective.owner = owner
-	sac_objective.update_explanation_text()
-	objectives += sac_objective
+	var/datum/objective/knowledge_ecult/know_objective = new
+	know_objective.owner = owner
+	know_objective.update_explanation_text()
+	objectives += know_objective
 
 /datum/antagonist/heretic/proc/forge_objective(string,assasination,protection)
 	switch(string)
@@ -268,21 +268,21 @@
 // Objectives //
 ////////////////
 
-/datum/objective/sacrifice_ecult
-	name = "sacrifice"
+/datum/objective/knowledge_ecult
+	name = "eldritch knowledges"
 
-/datum/objective/sacrifice_ecult/update_explanation_text()
+/datum/objective/knowledge_ecult/update_explanation_text()
 	. = ..()
-	target_amount = rand(2,6)
-	explanation_text = "Sacrifice at least [target_amount] people."
+	target_amount = rand(9,16)
+	explanation_text = "Research at least [target_amount] eldritch knowledges (you start with 3)."
 
-/datum/objective/sacrifice_ecult/check_completion()
+/datum/objective/knowledge_ecult/check_completion()
 	if(!owner)
 		return FALSE
 	var/datum/antagonist/heretic/cultie = owner.has_antag_datum(/datum/antagonist/heretic)
 	if(!cultie)
 		return FALSE
-	return cultie.total_sacrifices >= target_amount
+	return length(cultie.researched_knowledge) >= target_amount
 
 /datum/outfit/heretic
 	name = "Heretic (Preview only)"

--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -153,7 +153,8 @@
 		targets += caller
 	var/targ_len = length(targets)
 	var/smash_len = length(smashes)
-	var/number = max(targ_len * (4-(targ_len-1)) - smash_len,1)
+	var/number = max(2 + targ_len * (7 - targ_len) - smash_len,1) 
+	///7*x - x*x + 1 : 8 12 14 -> 8 4 2 1...
 
 	for(var/i in 0 to number)
 		var/turf/chosen_location = get_safe_random_station_turf()
@@ -200,7 +201,7 @@
 
 /obj/effect/broken_illusion/Initialize(mapload)
 	. = ..()
-	addtimer(CALLBACK(src,.proc/show_presence),15 SECONDS)
+	addtimer(CALLBACK(src,.proc/show_presence),rand(1200 SECONDS, 1800 SECONDS))
 
 	var/image/I = image('icons/effects/eldritch.dmi',src,null,OBJ_LAYER)
 	I.override = TRUE


### PR DESCRIPTION
Heretics :
- Augmenter délais entre utilisation influence(reality brech) et apparition : 15 secondes -> temps random entre 20 à 40 minutes. 
- Augmenter nombre d'influences : 1/2/3 heretiques ont 4/6/7 -> 8/12/14 influences sur la station. Pour info elles donnent 1 charge.
- Pour info, sacrifier une cible donnait déjà 2  charges (inchangé)
- L'objectif sacrifier 2-6 personnes est replacé par : débloquer 6-13 connaissances [dont 1 gratuite](+ les 3 de round_start)


