### PR TITLE
Maping vault maint

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -4425,12 +4425,12 @@
 /area/security/brig)
 "aop" = (
 /obj/structure/bed/dogbed/mcgriff,
-/mob/living/simple_animal/pet/dog/pug/mcgriff,
 /obj/machinery/requests_console/directional/west{
 	department = "Security";
 	departmentType = 5;
 	name = "Warden's Office Requests Console"
 	},
+/mob/living/simple_animal/pet/dog/pug/mcgriff,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "aoq" = (
@@ -6280,7 +6280,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
 	name = "Bridge External Access";
-	req_access_txt = "10;13"
+	req_access_txt = "13"
 	},
 /turf/open/floor/plating,
 /area/command/bridge)
@@ -6604,6 +6604,7 @@
 /turf/open/floor/plating,
 /area/command/bridge)
 "auV" = (
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/bridge)
 "auW" = (
@@ -6675,14 +6676,6 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/command/gateway)
-"avd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Dorm3Shutters";
-	name = "Dorm Shutters"
-	},
-/turf/open/floor/plating,
-/area/commons/dorms)
 "ave" = (
 /obj/structure/bed,
 /obj/machinery/button/door{
@@ -7089,8 +7082,10 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Bridge External Access";
-	req_access_txt = "10;13"
+	req_access_txt = "0";
+	req_one_access_txt = "19;65"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/bridge)
 "awd" = (
@@ -7158,7 +7153,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "awn" = (
@@ -7499,9 +7493,8 @@
 	},
 /area/maintenance/department/security/brig)
 "axh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/structure/sign/poster/official/ian,
+/turf/closed/wall/r_wall,
 /area/command/bridge)
 "axi" = (
 /turf/closed/wall/r_wall,
@@ -8087,6 +8080,11 @@
 /obj/machinery/light,
 /obj/machinery/camera/directional/south{
 	c_tag = "Bridge External Access"
+	},
+/obj/machinery/suit_storage_unit/standard_unit{
+	desc = "An industrial suit storage device carrying retro space suits. This one is blue.";
+	helmet_type = /obj/item/clothing/head/helmet/space/syndicate/blue;
+	suit_type = /obj/item/clothing/suit/space/syndicate/blue
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -8760,8 +8758,8 @@
 /area/command/heads_quarters/hop)
 "aBF" = (
 /obj/structure/bed/dogbed/ian,
-/mob/living/simple_animal/pet/dog/corgi/ian,
 /obj/machinery/status_display/evac/directional/north,
+/mob/living/simple_animal/pet/dog/corgi/ian,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "aBG" = (
@@ -8774,14 +8772,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
-"aBK" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/crowbar,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "aBL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -9894,10 +9884,9 @@
 /turf/closed/wall,
 /area/commons/storage/emergency/starboard)
 "aEU" = (
-/obj/item/storage/toolbox,
+/obj/structure/closet/emcloset/anchored,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/plating,
 /area/commons/storage/emergency/starboard)
 "aEZ" = (
@@ -10108,12 +10097,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aFD" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12";
+	welded = 1
 	},
-/obj/item/taperecorder,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/hallway/primary/central)
 "aFF" = (
 /obj/item/storage/box/lights/mixed,
@@ -10122,6 +10112,7 @@
 	},
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
 /area/commons/storage/emergency/starboard)
 "aFK" = (
@@ -10401,18 +10392,6 @@
 	},
 /turf/open/floor/plating,
 /area/commons/storage/emergency/starboard)
-"aGC" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = -32
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "aGF" = (
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
@@ -11602,6 +11581,14 @@
 	icon_state = "platingdmg1"
 	},
 /area/cargo/warehouse)
+"aMx" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/hallway/primary/central)
 "aMy" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/structure/cable,
@@ -13605,10 +13592,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
 "aUZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Pete"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
 "aVa" = (
@@ -13956,12 +13943,12 @@
 /obj/structure/sink/kitchen{
 	pixel_y = 28
 	},
-/mob/living/carbon/human/species/monkey/punpun,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/mob/living/carbon/human/species/monkey/punpun,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
 "aWf" = (
@@ -32301,6 +32288,7 @@
 /area/commons/dorms)
 "coe" = (
 /obj/machinery/light/small,
+/obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -32334,9 +32322,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/door/airlock/external{
-	name = "public external airlock"
-	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/commons/storage/emergency/starboard)
 "cot" = (
@@ -35203,11 +35189,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"doP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/stool/bar/directional/east,
-/turf/open/floor/iron,
-/area/engineering/main)
 "dpa" = (
 /obj/machinery/light{
 	dir = 1
@@ -35343,6 +35324,10 @@
 /obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron/white,
 /area/security/prison)
+"dtt" = (
+/obj/machinery/photocopier,
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "dtK" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -36169,15 +36154,6 @@
 	dir = 4
 	},
 /obj/machinery/status_display/evac/directional/west,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
-"enI" = (
-/obj/machinery/computer/cryopod{
-	pixel_y = 28
-	},
-/obj/machinery/cryopod{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "eoo" = (
@@ -37130,6 +37106,10 @@
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"fcz" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating,
+/area/commons/storage/emergency/starboard)
 "fcK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -37760,6 +37740,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"fFk" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
 "fFF" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -38304,11 +38290,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /turf/open/floor/plating/airless,
 /area/engineering/atmos)
-"gii" = (
-/obj/structure/chair,
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "giI" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -39788,9 +39769,6 @@
 	},
 /area/maintenance/department/science)
 "hFy" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -40789,6 +40767,13 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
+"iFU" = (
+/obj/item/pen,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/folder,
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "iGp" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/crossing/horizontal,
@@ -41110,6 +41095,15 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
+"iZO" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/crowbar,
+/obj/item/taperecorder,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "jat" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -41786,6 +41780,7 @@
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
 "jOB" = (
+/obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/commons/storage/emergency/starboard)
 "jPf" = (
@@ -42690,6 +42685,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
+"kIe" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp/green{
+	step_x = 0
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "kIo" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -43161,10 +43163,10 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/mob/living/simple_animal/butterfly,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/mob/living/simple_animal/butterfly,
 /turf/open/floor/grass,
 /area/science/genetics)
 "lfS" = (
@@ -43359,12 +43361,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"low" = (
-/obj/machinery/cryopod{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "lpW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43695,14 +43691,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"lKL" = (
-/obj/machinery/door/airlock{
-	name = "Starboard Emergency Storage"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/commons/storage/emergency/starboard)
 "lLb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -45348,6 +45336,12 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/science/mixing)
+"noS" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "noT" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -46600,10 +46594,10 @@
 /area/service/chapel/monastery)
 "oAk" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/lizard/wags_his_tail,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/mob/living/simple_animal/hostile/lizard/wags_his_tail,
 /turf/open/floor/iron,
 /area/service/janitor)
 "oAw" = (
@@ -46748,9 +46742,6 @@
 /area/maintenance/department/security/brig)
 "oFo" = (
 /obj/structure/closet/emcloset/anchored,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -46778,6 +46769,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
 /area/security)
+"oFY" = (
+/turf/closed/wall,
+/area/maintenance/department/bridge)
 "oGm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49371,10 +49365,10 @@
 /area/maintenance/department/engine)
 "rhT" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/butterfly,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/mob/living/simple_animal/butterfly,
 /turf/open/floor/grass,
 /area/medical/psychology)
 "rie" = (
@@ -49422,6 +49416,13 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/grass,
 /area/science/genetics)
+"rlO" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = -32
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "rlR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -50414,12 +50415,10 @@
 /turf/open/floor/grass,
 /area/medical/psychology)
 "rYC" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/obj/machinery/door/airlock/external{
-	name = "public external airlock"
-	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/commons/storage/emergency/starboard)
 "rYH" = (
@@ -50592,6 +50591,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"shV" = (
+/obj/structure/sign/poster/official/the_owl,
+/turf/closed/wall/r_wall,
+/area/command/bridge)
 "sij" = (
 /obj/structure/closet,
 /obj/item/food/meat/slab/monkey,
@@ -50861,6 +50864,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"swW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "sxe" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -51358,6 +51368,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"sUC" = (
+/obj/item/paper_bin,
+/obj/structure/table,
+/obj/item/pen,
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "sUP" = (
 /obj/machinery/meter/atmos/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -51452,6 +51468,10 @@
 /obj/item/storage/backpack/satchel/explorer,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"sZL" = (
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "sZP" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
@@ -53046,12 +53066,12 @@
 "ulV" = (
 /obj/effect/landmark/event_spawn,
 /mob/living/simple_animal/bot/secbot{
-	arrest_type = 1;
+	!INVALID_VAR! = 1;
 	health = 45;
 	icon_state = "secbot1";
-	idcheck = 1;
+	!INVALID_VAR! = 1;
 	name = "Sergeant-at-Armsky";
-	weaponscheck = 1
+	!INVALID_VAR! = 1
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -53113,6 +53133,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"uoq" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Bridge External Access";
+	req_access_txt = "0";
+	req_one_access_txt = "13;19;65"
+	},
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/command/bridge)
 "uos" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -56126,6 +56159,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"wOk" = (
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "wOF" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio8";
@@ -57064,10 +57100,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"xwC" = (
-/obj/structure/chair/stool/bar/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "xwX" = (
 /obj/machinery/door/airlock/security{
 	name = "Equipment Room";
@@ -57088,6 +57120,10 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
+"xxl" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "xxo" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -57216,6 +57252,10 @@
 	},
 /turf/closed/wall,
 /area/cargo/storage)
+"xBf" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "xBB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -57639,6 +57679,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"xWI" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plating,
+/area/commons/storage/emergency/starboard)
 "xWN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -57761,6 +57805,10 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"ydr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "ydu" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -57887,6 +57935,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"yjl" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "yjt" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -90926,7 +90978,7 @@ ahi
 atZ
 auV
 awc
-ayg
+fRJ
 fRJ
 azp
 aAH
@@ -91181,10 +91233,10 @@ aaa
 aaa
 ahi
 atY
-atY
-atY
-axh
-axh
+uoq
+arA
+shV
+arA
 axh
 aAH
 aBB
@@ -91437,12 +91489,12 @@ aaa
 aaa
 aaa
 aaa
-aht
-aaa
-aaa
-aht
-aaa
-aaa
+oFY
+xxl
+rlO
+wOk
+noS
+sUC
 aAH
 aBC
 hQV
@@ -91696,10 +91748,10 @@ apT
 apT
 apT
 apT
-aaa
-aht
-aaa
-aaa
+xxl
+dtt
+iFU
+kIe
 aAH
 aBD
 aaT
@@ -91953,10 +92005,10 @@ auc
 asV
 aua
 apT
-awd
+aMx
 axi
-aaa
-aaa
+ydr
+ydr
 aAH
 aBE
 pHo
@@ -92210,7 +92262,7 @@ rCR
 rCR
 aub
 auZ
-awe
+ptL
 awd
 aaa
 aaa
@@ -92984,11 +93036,11 @@ apT
 awh
 awd
 abI
-awd
+axi
 aAI
 svR
 qNB
-jcT
+sZL
 aAN
 aFC
 aGz
@@ -93242,7 +93294,7 @@ jWj
 awd
 awd
 awd
-jcT
+awe
 jcT
 rQV
 jcT
@@ -93756,12 +93808,12 @@ awk
 awd
 awd
 awd
-jcT
-eZv
-jcT
-jcT
-rLQ
-jcT
+aAM
+iZO
+aDa
+awJ
+swW
+ptL
 jcT
 aKa
 xvO
@@ -94012,14 +94064,14 @@ avb
 awl
 awd
 abI
+axi
+aAN
 awd
-aAM
-aBK
-aDa
-awJ
-gii
+awd
+aAN
+aAN
 aFD
-aDa
+aAN
 aAN
 nIt
 ame
@@ -94269,14 +94321,14 @@ avc
 awm
 awd
 abI
-axi
-aAN
-awd
-awd
-aAN
-aAN
-awd
-awd
+aaa
+aaa
+aaa
+aaa
+aiS
+ato
+xBf
+ato
 aAN
 aIg
 aKb
@@ -94523,18 +94575,18 @@ cBU
 cBU
 cBU
 cBU
-awd
+fFk
 axi
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-awd
+aiT
+aiT
+aiS
+aiT
+aiT
+aiS
+yjl
+xBf
+aqZ
+aAN
 xvO
 ame
 jcT
@@ -94776,22 +94828,22 @@ aaa
 aaa
 aaa
 aaa
-aht
-aaa
-aht
-aaa
-aaa
-aht
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-awd
+aiS
+xBf
+xBf
+xBf
+xBf
+xBf
+xBf
+xBf
+xBf
+xBf
+xBf
+xBf
+xBf
+xBf
+auq
+aAN
 xvO
 ame
 jcT
@@ -95034,10 +95086,10 @@ aiS
 aiS
 aiS
 aiS
+xBf
 aiS
-aiS
-avd
-avd
+apX
+apX
 apX
 ayi
 ayi
@@ -95303,7 +95355,7 @@ aBM
 aDb
 aET
 oFo
-jOB
+fFL
 qbZ
 aET
 xvO
@@ -95559,9 +95611,9 @@ apX
 aBN
 aDc
 aET
-aET
+fcz
 cor
-aET
+xWI
 aET
 hFy
 ame
@@ -95819,7 +95871,7 @@ aET
 aEU
 fFL
 jOB
-lKL
+aET
 xvO
 ame
 eZv
@@ -96589,7 +96641,7 @@ gLn
 cop
 qxa
 qxa
-aGC
+qxa
 qxa
 dPO
 ame
@@ -98631,7 +98683,7 @@ aiT
 aiS
 aiS
 aiS
-low
+ayu
 icK
 pfF
 emV
@@ -98888,7 +98940,7 @@ sFK
 sFK
 sFK
 aiS
-enI
+ayu
 fVJ
 lFK
 lJM
@@ -99145,7 +99197,7 @@ aiT
 aiS
 sFK
 aiS
-low
+ayu
 eHq
 wKP
 wRG

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -6678,11 +6678,6 @@
 /area/command/gateway)
 "ave" = (
 /obj/structure/bed,
-/obj/machinery/button/door{
-	id = "Dorm3Shutters";
-	name = "Privacy Shutters Control";
-	pixel_y = 26
-	},
 /obj/item/bedsheet/dorms,
 /turf/open/floor/wood,
 /area/commons/dorms)
@@ -53066,12 +53061,9 @@
 "ulV" = (
 /obj/effect/landmark/event_spawn,
 /mob/living/simple_animal/bot/secbot{
-	!INVALID_VAR! = 1;
 	health = 45;
 	icon_state = "secbot1";
-	!INVALID_VAR! = 1;
-	name = "Sergeant-at-Armsky";
-	!INVALID_VAR! = 1
+	name = "Sergeant-at-Armsky"
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)


### PR DESCRIPTION
Ajout de maintenances autour du couloir du vault

- Rend le bridge, le bureau hop et le vault plus vulnérables. 
- La maint nord encercle plus la station. 
- Combi spatiale hop (relativement facile a voler)

Avant : 
![couloir_vault_before](https://user-images.githubusercontent.com/7497261/142515143-714d8772-b92a-4641-aebf-d1e5cb237595.png)
Après :
![couloir_vault_after](https://user-images.githubusercontent.com/7497261/142515163-82a6b732-950a-4ffc-b129-506b016b5fdb.png)


