### PR TITLE
Pubby : Update ai satellite

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -425,6 +425,7 @@
 /area/ai_monitored/turret_protected/ai)
 "abW" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ai_monitored/turret_protected/ai)
 "abY" = (
@@ -461,12 +462,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ai_monitored/turret_protected/ai)
 "ach" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ai_monitored/turret_protected/ai)
 "aci" = (
@@ -523,7 +526,6 @@
 	pixel_y = -24
 	},
 /obj/machinery/holopad/secure,
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/south{
 	broadcasting = 1;
 	frequency = 1447;
@@ -576,6 +578,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "acv" = (
@@ -637,7 +640,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "acF" = (
@@ -685,7 +687,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ai_monitored/turret_protected/ai)
 "acM" = (
@@ -704,6 +705,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "acT" = (
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "acU" = (
@@ -730,7 +732,6 @@
 	req_access_txt = "65"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -739,9 +740,15 @@
 /area/ai_monitored/turret_protected/ai)
 "add" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
 "ade" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/ai_sat_ext_as)
+"adf" = (
 /obj/structure/table/glass,
 /obj/item/stack/sheet/iron,
 /obj/item/stack/sheet/glass{
@@ -756,17 +763,12 @@
 	pixel_x = -8;
 	pixel_y = 4
 	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/ai_sat_ext_as)
-"adf" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/modular_computer/console/preset/civilian,
+/obj/item/stack/sheet/mineral/plasma/five,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "adg" = (
 /obj/machinery/mecha_part_fabricator,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "adh" = (
@@ -777,6 +779,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "adi" = (
@@ -800,6 +804,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "adl" = (
@@ -823,23 +829,16 @@
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ado" = (
-/obj/structure/table,
-/obj/item/pen,
-/obj/item/paper_bin,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 8
+	},
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
-"adq" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/ai_sat_ext_as)
 "ads" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light{
@@ -859,6 +858,7 @@
 	network = list("minisat")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "adu" = (
@@ -879,6 +879,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "ai-sat-inner"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "adx" = (
@@ -905,7 +906,6 @@
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -913,6 +913,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "ai-sat-inner"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "adC" = (
@@ -927,7 +928,6 @@
 	c_tag = "MiniSat Maintenance Starboard Fore";
 	network = list("minisat")
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -993,6 +993,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "ai-sat-center"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "adO" = (
@@ -1239,6 +1240,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "ai-sat-center"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "aeR" = (
@@ -1258,7 +1260,6 @@
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "ai-sat-right"
 	},
@@ -1326,7 +1327,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "afb" = (
@@ -1351,7 +1351,6 @@
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "afd" = (
@@ -1380,7 +1379,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "aff" = (
@@ -1413,7 +1411,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afh" = (
@@ -1438,7 +1435,6 @@
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "afj" = (
@@ -1466,7 +1462,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "afl" = (
@@ -1554,6 +1549,7 @@
 "afy" = (
 /obj/effect/landmark/start/cyborg,
 /obj/item/beacon,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afz" = (
@@ -1655,6 +1651,7 @@
 /area/cargo/warehouse/upper)
 "afP" = (
 /obj/machinery/holopad/secure,
+/obj/structure/cable,
 /mob/living/simple_animal/bot/secbot/pingsky,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -1865,6 +1862,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = -32
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "agE" = (
@@ -3714,7 +3712,7 @@
 /turf/open/floor/iron/white,
 /area/security/brig)
 "amd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "ame" = (
@@ -4425,12 +4423,12 @@
 /area/security/brig)
 "aop" = (
 /obj/structure/bed/dogbed/mcgriff,
-/mob/living/simple_animal/pet/dog/pug/mcgriff,
 /obj/machinery/requests_console/directional/west{
 	department = "Security";
 	departmentType = 5;
 	name = "Warden's Office Requests Console"
 	},
+/mob/living/simple_animal/pet/dog/pug/mcgriff,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "aoq" = (
@@ -5090,11 +5088,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
-"aqw" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "aqx" = (
 /obj/machinery/power/smes,
 /obj/effect/turf_decal/tile/yellow{
@@ -8760,8 +8753,8 @@
 /area/command/heads_quarters/hop)
 "aBF" = (
 /obj/structure/bed/dogbed/ian,
-/mob/living/simple_animal/pet/dog/corgi/ian,
 /obj/machinery/status_display/evac/directional/north,
+/mob/living/simple_animal/pet/dog/corgi/ian,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "aBG" = (
@@ -9539,7 +9532,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "aEc" = (
@@ -13605,10 +13597,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
 "aUZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Pete"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
 "aVa" = (
@@ -13956,12 +13948,12 @@
 /obj/structure/sink/kitchen{
 	pixel_y = 28
 	},
-/mob/living/carbon/human/species/monkey/punpun,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/mob/living/carbon/human/species/monkey/punpun,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
 "aWf" = (
@@ -35203,11 +35195,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"doP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/stool/bar/directional/east,
-/turf/open/floor/iron,
-/area/engineering/main)
 "dpa" = (
 /obj/machinery/light{
 	dir = 1
@@ -36169,15 +36156,6 @@
 	dir = 4
 	},
 /obj/machinery/status_display/evac/directional/west,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
-"enI" = (
-/obj/machinery/computer/cryopod{
-	pixel_y = 28
-	},
-/obj/machinery/cryopod{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "eoo" = (
@@ -38743,12 +38721,12 @@
 /turf/open/floor/plating,
 /area/commons/storage/emergency/starboard)
 "gAY" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "gBb" = (
@@ -39634,6 +39612,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"hxk" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "hxB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -39737,6 +39720,7 @@
 /area/engineering/supermatter/room)
 "hCS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "hDg" = (
@@ -39935,6 +39919,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal)
+"hMe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/ai_sat_ext_as)
 "hMt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -41762,6 +41753,10 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"jOj" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/ai_sat_ext_as)
 "jOk" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input{
 	dir = 1
@@ -42131,6 +42126,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "ai-sat-left"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "kkk" = (
@@ -42909,6 +42905,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"kTX" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/ai_monitored/turret_protected/ai)
 "kUj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -42927,6 +42928,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "kUH" = (
@@ -43161,10 +43163,10 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/mob/living/simple_animal/butterfly,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/mob/living/simple_animal/butterfly,
 /turf/open/floor/grass,
 /area/science/genetics)
 "lfS" = (
@@ -43359,12 +43361,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"low" = (
-/obj/machinery/cryopod{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "lpW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44326,6 +44322,10 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/cargo/qm)
+"msf" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "msw" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -45149,6 +45149,14 @@
 /obj/item/chair/stool,
 /turf/open/floor/carpet,
 /area/service/abandoned_gambling_den)
+"ngG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/grimy,
+/area/ai_monitored/turret_protected/aisat_interior)
 "ngO" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Access"
@@ -46252,6 +46260,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "olO" = (
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_ap)
 "olV" = (
@@ -46600,10 +46609,10 @@
 /area/service/chapel/monastery)
 "oAk" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/lizard/wags_his_tail,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/mob/living/simple_animal/hostile/lizard/wags_his_tail,
 /turf/open/floor/iron,
 /area/service/janitor)
 "oAw" = (
@@ -47166,6 +47175,17 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"pbS" = (
+/obj/machinery/door/airlock/external{
+	name = "MiniSat External Access";
+	req_access_txt = "65"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "ai-sat-entrance"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/aisat_interior)
 "pcg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -47674,6 +47694,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"pEi" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/ai_monitored/turret_protected/ai)
 "pEv" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
@@ -49027,6 +49054,15 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"qLK" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
+/area/ai_monitored/turret_protected/ai)
 "qLU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -49371,10 +49407,10 @@
 /area/maintenance/department/engine)
 "rhT" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/butterfly,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/mob/living/simple_animal/butterfly,
 /turf/open/floor/grass,
 /area/medical/psychology)
 "rie" = (
@@ -50922,6 +50958,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"syI" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/ai_monitored/turret_protected/ai_sat_ext_as)
 "syK" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -51434,7 +51474,6 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "sYY" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -52364,6 +52403,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"tFu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "tGj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52395,6 +52438,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
+"tJt" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/ai_monitored/turret_protected/ai)
 "tJX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -53046,12 +53093,12 @@
 "ulV" = (
 /obj/effect/landmark/event_spawn,
 /mob/living/simple_animal/bot/secbot{
-	arrest_type = 1;
+	!INVALID_VAR! = 1;
 	health = 45;
 	icon_state = "secbot1";
-	idcheck = 1;
+	!INVALID_VAR! = 1;
 	name = "Sergeant-at-Armsky";
-	weaponscheck = 1
+	!INVALID_VAR! = 1
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -53365,6 +53412,7 @@
 /area/medical/medbay/central)
 "uyY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_sat_ext_as)
 "uzn" = (
@@ -54647,6 +54695,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
+"vFW" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/ai_monitored/turret_protected/ai)
 "vFZ" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -57064,10 +57116,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"xwC" = (
-/obj/structure/chair/stool/bar/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "xwX" = (
 /obj/machinery/door/airlock/security{
 	name = "Equipment Room";
@@ -57250,14 +57298,6 @@
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"xEA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/ai_sat_ext_as)
 "xEI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -57272,6 +57312,13 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal)
+"xFr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/ai_monitored/turret_protected/ai)
 "xFF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
@@ -57439,6 +57486,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"xML" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/ai_monitored/turret_protected/ai)
 "xMQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/dim{
@@ -89590,14 +89644,14 @@ aaa
 aby
 abI
 abO
-abV
-acc
-sWM
-abY
-abY
+kTX
+xFr
+pEi
+vFW
 abW
 acn
 acw
+abY
 abY
 abV
 acc
@@ -89851,9 +89905,9 @@ abW
 acd
 ace
 ace
-ace
 amd
-acC
+amd
+hxk
 acC
 acC
 acC
@@ -89862,7 +89916,7 @@ acw
 acP
 acY
 sPa
-vHR
+kbV
 acP
 adV
 adV
@@ -89870,7 +89924,7 @@ cnD
 adV
 adV
 acP
-kbV
+vHR
 acP
 acP
 acP
@@ -90109,8 +90163,8 @@ ace
 ace
 abO
 abO
-abO
 bhU
+abO
 abO
 abO
 acC
@@ -90361,13 +90415,13 @@ aaa
 aby
 aaa
 abO
-abY
+vFW
 ace
 abO
 abO
 abO
-abO
 bhU
+abO
 abO
 abO
 abO
@@ -90376,7 +90430,7 @@ rlV
 abO
 add
 adk
-cCO
+ngG
 adX
 adV
 adV
@@ -90384,7 +90438,7 @@ cnD
 adV
 adV
 adX
-hoR
+hQd
 afw
 kfl
 agf
@@ -90618,18 +90672,18 @@ aaa
 aby
 aaa
 abO
-abY
+vFW
 ace
 abO
 abO
 acF
-ace
+amd
 acq
 abO
 abO
 abO
 aaN
-abY
+vFW
 acT
 add
 adl
@@ -90875,7 +90929,7 @@ aaa
 aby
 abJ
 abO
-abY
+vFW
 acf
 abO
 abO
@@ -90889,20 +90943,20 @@ acD
 acL
 sYY
 adb
-ieU
+cCO
 sFL
 adM
 kUt
-hQd
-hQd
-hQd
-hQd
+hoR
+hoR
+hoR
+hoR
 aeO
 aff
 afy
 afP
-agf
-agR
+msf
+pbS
 agD
 agR
 ahi
@@ -91132,18 +91186,18 @@ aaa
 aby
 aaa
 abO
-abY
+vFW
 ace
 abO
 abO
 acF
-aqw
+ace
 acs
 abO
 abO
 abO
 adT
-abY
+vFW
 acT
 add
 adn
@@ -91389,7 +91443,7 @@ aaa
 aby
 aaa
 abO
-abY
+vFW
 ace
 abO
 abO
@@ -91646,15 +91700,15 @@ aaa
 aby
 aaa
 abO
-abV
+kTX
 ace
 ace
 abO
 abO
 abO
 bhU
-abO
-abO
+tJt
+tJt
 adT
 adT
 sWM
@@ -91909,16 +91963,16 @@ ace
 ace
 ace
 aFc
-adT
-adT
-adT
-adT
+tFu
+tFu
+tFu
+tFu
 acd
 acw
 acU
 ade
-ael
-xEA
+jOj
+szb
 acU
 adV
 adV
@@ -91926,7 +91980,7 @@ cnD
 adV
 adV
 acU
-szb
+hMe
 acU
 acU
 acU
@@ -92162,19 +92216,19 @@ abI
 abO
 ach
 acg
-aci
-abY
-abY
+qLK
+vFW
+vFW
 abW
 acu
-acw
-abY
+xML
+vFW
 ach
 acg
-aci
-acU
+qLK
+syI
 adf
-adq
+ael
 adD
 acU
 acU
@@ -92429,18 +92483,18 @@ abO
 abO
 abO
 abO
-acU
+syI
 adg
 uyY
 gAY
 aeS
-szb
-szb
-szb
-szb
-szb
+hMe
+hMe
+hMe
+hMe
+hMe
 aeS
-szb
+hMe
 ezt
 afS
 acU
@@ -98631,7 +98685,7 @@ aiT
 aiS
 aiS
 aiS
-low
+ayu
 icK
 pfF
 emV
@@ -98888,7 +98942,7 @@ sFK
 sFK
 sFK
 aiS
-enI
+ayu
 fVJ
 lFK
 lJM
@@ -99145,7 +99199,7 @@ aiT
 aiS
 sFK
 aiS
-low
+ayu
 eHq
 wKP
 wRG


### PR DESCRIPTION
Mis a jour de électricité du satellite IA

- Décalages portes IA : Baisse défense (une tourelle de moins a détruire pour tuer IA. SMES Snipable après une tourelle détruite)
- Électrification renforced windows du core.
- SMES IA plus hotwire
- PACMAN avant SMES dans le satelite IA
- cable avant SMES qui va jusqu’à l'entrée du satellite si un inge veut le raccorder a la grid.

Avant : 
![sat_ia_pre](https://user-images.githubusercontent.com/7497261/142515652-b4c5c631-62bc-494e-8ed1-fef781dc06a1.png)

Après :
![sat_ia_post](https://user-images.githubusercontent.com/7497261/142515661-ed50e151-e461-485c-8f36-a645aa61b396.png)
 
