### PR TITLE
Blood brothers rework 

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/crates/syndicate.dm
@@ -1,0 +1,50 @@
+/obj/structure/closet/crate/syndicate
+	var/frequency
+	var/detonate_code
+	var/ping_code
+	var/obj/item/radio/radio //The crate radio to indicate it's position to syndicate agents
+
+/obj/structure/closet/crate/syndicate/Initialize(mapload)
+	. = ..()
+	frequency = return_unused_frequency()
+	ping_code = rand(1,50)
+	detonate_code = rand(51,99)
+	SSradio.add_object(src, frequency, RADIO_SIGNALER)
+
+	radio = new/obj/item/radio(src)
+	radio.keyslot = new /obj/item/encryptionkey/syndicate
+
+	RegisterSignal(src, COMSIG_MOVABLE_Z_CHANGED, .proc/ping_crate_pod_drop)
+
+/obj/structure/closet/crate/syndicate/Destroy()
+	QDEL_NULL(radio)
+	return ..()
+
+/obj/structure/closet/crate/syndicate/receive_signal(datum/signal/signal)
+	if(!signal)
+		return
+	if(signal.data["code"] == ping_code)
+		ping_crate()
+	if(signal.data["code"] == detonate_code)
+		detonate_crate()
+
+/obj/structure/closet/crate/syndicate/proc/ping_crate_pod_drop()
+	if(istype(get_area(src), /area/centcom/supplypod/supplypod_temp_holding))
+		return
+	UnregisterSignal(src, COMSIG_MOVABLE_Z_CHANGED)
+	ping_crate()
+
+/obj/structure/closet/crate/syndicate/proc/ping_crate()
+	var/turf/T = get_turf(src)
+	radio.set_frequency(FREQ_SYNDICATE)
+	radio.talk_into(src, "Crate with frequency [frequency/10] Hz, ping code [ping_code] and detonation code [detonate_code] at [T.x],[T.y],[T.z] in [get_area(src)].", FREQ_SYNDICATE)
+
+/obj/structure/closet/crate/syndicate/proc/detonate_crate()
+	explosion(src, devastation_range = 0, heavy_impact_range = 1, light_impact_range = 3, flame_range = 3, flash_range = 3)
+
+
+/obj/structure/closet/crate/syndicate/after_open(mob/living/user, force)
+	. = ..()
+	var/turf/T = get_turf(src)
+	radio.set_frequency(FREQ_SYNDICATE)
+	radio.talk_into(src, "Crate with frequency [frequency/10] Hz opened at [T.x],[T.y],[T.z] in [get_area(src)].", FREQ_SYNDICATE)

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -48,6 +48,8 @@
 
 
 /datum/antagonist/brother/proc/drop_pod()
+	if(!src)
+		return
 	for(var/datum/round_event_control/stray_cargo/syndicate/E in SSevents.control)
 		E.runEvent(random = TRUE)
 

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -23,7 +23,34 @@
 	objectives += team.objectives
 	owner.special_role = special_role
 	finalize_brother()
+
+
+	addtimer(CALLBACK(src,.proc/drop_pod),rand(600 SECONDS, 3000 SECONDS))
+
+	/// Try to give them a syndicate encryption key
+	var/mob/living/carbon/C = owner.current
+	if(!ishuman(C))
+		return
+
+	var/obj/item/encryptionkey/syndicate/syndie_key = new(C)
+	var/list/slots = list (
+		"backpack" = ITEM_SLOT_BACKPACK,
+		"left pocket" = ITEM_SLOT_LPOCKET,
+		"right pocket" = ITEM_SLOT_RPOCKET
+	)
+	var/where = C.equip_in_one_of_slots(syndie_key, slots)
+	if (!where)
+		to_chat(C, "The Syndicate were unfortunately unable to get you a syndicate encryption key.")
+	else
+		to_chat(C, "The syndicate encryption key in your [where] will help you cooperate with your fellow syndicates agents.")
+
 	return ..()
+
+
+/datum/antagonist/brother/proc/drop_pod()
+	for(var/datum/round_event_control/stray_cargo/syndicate/E in SSevents.control)
+		E.runEvent(random = TRUE)
+
 
 /datum/antagonist/brother/on_removal()
 	if(owner.current)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2662,7 +2662,7 @@
 	special = TRUE ///Cannot be ordered via cargo
 	contains = list()
 	crate_name = "syndicate gear crate"
-	crate_type = /obj/structure/closet/crate
+	crate_type = /obj/structure/closet/crate/syndicate
 	var/crate_value = 30 ///Total TC worth of contained uplink items
 
 ///Generate assorted uplink items, taking into account the same surplus modifiers used for surplus crates

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -90,6 +90,7 @@
 	earliest_start = 30 MINUTES
 
 /datum/round_event/stray_cargo/syndicate
+	announceChance = 20
 	possible_pack_types = list(/datum/supply_pack/misc/syndicate)
 
 ///Apply the syndicate pod skin

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1599,6 +1599,7 @@
 #include "code\game\objects\structures\crates_lockers\crates\critter.dm"
 #include "code\game\objects\structures\crates_lockers\crates\large.dm"
 #include "code\game\objects\structures\crates_lockers\crates\secure.dm"
+#include "code\game\objects\structures\crates_lockers\crates\syndicate.dm"
 #include "code\game\objects\structures\crates_lockers\crates\wooden.dm"
 #include "code\game\objects\structures\icemoon\cave_entrance.dm"
 #include "code\game\objects\structures\lavaland\geyser.dm"


### PR DESCRIPTION
- commencent avec une syndie encryption key
- 1 crates syndicat pod drop par blood brother
- les crates syndicat donnent leur position, fréquences et codes sur la radio syndicat quand drop/ping (avec un signaler)
- les crates syndicat indiquent quand elles sont ouvertes sur la radio syndicat (et leur position)
- les crates explosent quand signaler avec leur fréquence et code détonation
- reduit la probabilité d'annonce centcom de l'evenement

