### PR TITLE
[CONFIG /!\] Remove security borgs

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -70,12 +70,12 @@ HUMANS_NEED_SURNAMES
 
 
 ## ALERT LEVELS ###
-ALERT_GREEN Toutes les menaces sur la station sont passées. La securité ne dois pas avoir ses armes visible, les lois sur la vie privée sont de nouveau en vigeur.
-ALERT_BLUE_UPTO La station à reçu des informations viables à propos d'une activitée hostile sur la station. Les agents de securité peuvent avoir leurs armes visibles, les fouilles aleatoires sont permises.
-ALERT_BLUE_DOWNTO La menace immediate est passée. Les agents de securité ne doivent plus avoir leurs armes de sortie constemment. Les fouilles aleatoire sont toujours autorisées.
-ALERT_RED_UPTO Il y à une serieuse menace immediate sur la station. Les agents de securité peuvent avoir leurs armes sorties en permanence. Accessoirement, l'accès requis pour certaines portes a été augmenté.
-ALERT_RED_DOWNTO La destruction de la station a été evitée. Il y a cepandant toujours une mance serieuse sur la station. La securité peuvent avoir leurs armes sorties en permanance, les fouilles aleatoire sont autorisées et encouragées.
-ALERT_DELTA Destruction de la station imminante. Tout l'equipage doit obeir aux ordres des chefs de service. Toute violation à leurs ordres peut être puni de mort. Ceci n'est pas un exercice.
+ALERT_GREEN Toutes les menaces sur la station sont passÃ©es. La securitÃ© ne dois pas avoir ses armes visible, les lois sur la vie privÃ©e sont de nouveau en vigeur.
+ALERT_BLUE_UPTO La station Ã  reÃ§u des informations viables Ã  propos d'une activitÃ©e hostile sur la station. Les agents de securitÃ© peuvent avoir leurs armes visibles, les fouilles aleatoires sont permises.
+ALERT_BLUE_DOWNTO La menace immediate est passÃ©e. Les agents de securitÃ© ne doivent plus avoir leurs armes de sortie constemment. Les fouilles aleatoire sont toujours autorisÃ©es.
+ALERT_RED_UPTO Il y Ã  une serieuse menace immediate sur la station. Les agents de securitÃ© peuvent avoir leurs armes sorties en permanence. Accessoirement, l'accÃ¨s requis pour certaines portes a Ã©tÃ© augmentÃ©.
+ALERT_RED_DOWNTO La destruction de la station a Ã©tÃ© evitÃ©e. Il y a cepandant toujours une mance serieuse sur la station. La securitÃ© peuvent avoir leurs armes sorties en permanance, les fouilles aleatoire sont autorisÃ©es et encouragÃ©es.
+ALERT_DELTA Destruction de la station imminante. Tout l'equipage doit obeir aux ordres des chefs de service. Toute violation Ã  leurs ordres peut Ãªtre puni de mort. Ceci n'est pas un exercice.
 
 
 
@@ -150,7 +150,7 @@ ALLOW_AI_MULTICAM
 
 ## Secborg ###
 ## Uncomment to prevent the security cyborg model from being chosen
-#DISABLE_SECBORG
+DISABLE_SECBORG
 
 ## Peacekeeper Borg ###
 ## Uncomment to prevent the peacekeeper cyborg model from being chosen


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Retire les borgs de sécurité

## Why It's Good For The Game

CF:
https://tgstation13.org/wiki/Rules "Silicons are not Security"
https://tgstation13.org/phpBB/viewtopic.php?f=10&t=6217&p=163916&hilit=sec+borg#p163916
https://tgstation13.org/phpBB/viewtopic.php?f=10&t=4545&p=116923&hilit=sec+borg#p116923

Impliquer les silicons dans la sécurité est une très mauvaise idée pour l'équilibrage sec/antag. Les silicons deviennent une arme que les deux camps peuvent abuser, securité comme traitres tandis que d'autres antagonistes sont totalement délaissés de cette dynamique. 
Les Secborgs ont été retirés pour une très bonne raison sur Tgstation, les threads que j'ai cité ne sont qu'une infime partie des arguments qui ont participés à leur désactivation mais bon leur forum est un peu bordélique

## Changelog



:cl:

config: Remove sec borgs

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
