### PR TITLE
Grant Uncommon to Foreign Jellys

### DIFF
--- a/code/datums/quirks/neutral.dm
+++ b/code/datums/quirks/neutral.dm
@@ -43,13 +43,13 @@
 /datum/quirk/foreigner/add()
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	human_holder.add_blocked_language(/datum/language/common)
-	if(ishumanbasic(human_holder))
+	if(ishumanbasic(human_holder) | is_species(human_holder, /datum/species/jelly)) // Humans and jellypeople
 		human_holder.grant_language(/datum/language/uncommon)
 
 /datum/quirk/foreigner/remove()
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	human_holder.remove_blocked_language(/datum/language/common)
-	if(ishumanbasic(human_holder))
+	if(ishumanbasic(human_holder) | is_species(human_holder, /datum/species/jelly))
 		human_holder.remove_language(/datum/language/uncommon)
 
 /datum/quirk/vegetarian


### PR DESCRIPTION
## About The Pull Request

Donne Uncommon aux jellys foreign.
Permet aux jellys roundstart avec le quirk *foreign* de pouvoir parler.

## Changelog

:cl:
fix: donne *Uncommon* aux jellys étrangers _(foreign)_
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
