### PR TITLE
Increase EMP energy drain on mech.

### DIFF
--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -29,4 +29,6 @@
 				T.emp_act(EMP_LIGHT)
 		else if(distance <= light_range)
 			T.emp_act(EMP_LIGHT)
+	if (heavy_range > 3)
+		empulse(epicenter, heavy_range/3, 2*heavy_range/3, log=0)
 	return 1

--- a/code/modules/vehicles/mecha/combat/phazon.dm
+++ b/code/modules/vehicles/mecha/combat/phazon.dm
@@ -16,6 +16,15 @@
 	max_equip = 3
 	phase_state = "phazon-phase"
 
+/obj/vehicle/sealed/mecha/combat/phazon/emp_act(severity)
+	. = ..()
+	if (. & EMP_PROTECT_SELF)
+		return
+	if(get_charge())
+		use_power((cell.charge/8 )/(severity))
+	addtimer(CALLBACK(src, /obj/vehicle/sealed/mecha/proc/restore_equipment), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+
+
 /obj/vehicle/sealed/mecha/combat/phazon/generate_actions()
 	. = ..()
 	initialize_passenger_action_type(/datum/action/vehicle/sealed/mecha/mech_toggle_phasing)

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -161,7 +161,7 @@
 	if (. & EMP_PROTECT_SELF)
 		return
 	if(get_charge())
-		use_power((cell.charge/3)/(severity*2))
+		use_power(min(cell.charge, (cell.charge/8 + cell.maxcharge/10 )/(severity)))
 		take_damage(30 / severity, BURN, ENERGY, 1)
 	log_message("EMP detected", LOG_MECHA, color="red")
 
@@ -172,7 +172,7 @@
 			occupant.update_mouse_pointer()
 	if(!equipment_disabled && LAZYLEN(occupants)) //prevent spamming this message with back-to-back EMPs
 		to_chat(occupants, span_warning("Error -- Connection to equipment control unit has been lost."))
-	addtimer(CALLBACK(src, /obj/vehicle/sealed/mecha/proc/restore_equipment), 3 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, /obj/vehicle/sealed/mecha/proc/restore_equipment), 4 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 	equipment_disabled = 1
 
 /obj/vehicle/sealed/mecha/should_atmos_process(datum/gas_mixture/air, exposed_temperature)


### PR DESCRIPTION
Need 6-7 heavy EMP to drain most mech.
Need 4 heavy EMP to drain phazon.
EMP explosion deal a second EMP explosion with 1/3 of their range (if their heavy range >4). This make EMP grenade deal bonus damage to mech at short range (compared to EMP guns).