### PR TITLE
Revert "Ballistic to Energy" partiellement + Réajustement des Thermal Pistols

### DIFF
--- a/code/game/objects/items/storage/holsters.dm
+++ b/code/game/objects/items/storage/holsters.dm
@@ -6,7 +6,6 @@
 	inhand_icon_state = "holster"
 	worn_icon_state = "holster"
 	alternate_worn_layer = UNDER_SUIT_LAYER
-	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/storage/belt/holster/equipped(mob/user, slot)
 	. = ..()
@@ -58,7 +57,6 @@
 /obj/item/storage/belt/holster/detective
 	name = "detective's holster"
 	desc = "A holster able to carry handguns and some ammo. WARNING: Badasses only."
-	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/storage/belt/holster/detective/ComponentInitialize()
 	. = ..()

--- a/code/modules/cargo/exports/weapons.dm
+++ b/code/modules/cargo/exports/weapons.dm
@@ -36,6 +36,10 @@
 	unit_name = "energy gun"
 	export_types = list(/obj/item/gun/energy/e_gun)
 
+/datum/export/weapon/wt550
+	unit_name = "WT-550 automatic rifle"
+	export_types = list(/obj/item/gun/ballistic/automatic/wt550)
+
 /datum/export/weapon/inferno
 	cost = CARGO_CRATE_VALUE * 1.5
 	unit_name = "inferno pistol"

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -66,6 +66,18 @@
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/weaponcrafting/gunkit/hellgun)
 
+/datum/supply_pack/goody/wt550_single
+	name = "WT-550 Auto Rifle Single-Pack"
+	desc = "Contains one high-powered, semiautomatic rifles chambered in 4.6x30mm."
+	cost = PAYCHECK_HARD * 20
+	contains = list(/obj/item/gun/ballistic/automatic/wt550)
+
+/datum/supply_pack/goody/wt550ammo_single
+	name = "WT-550 Auto Rifle Ammo Single-Pack"
+	desc = "Contains a 20-round magazine for the WT-550 Auto Rifle. Each magazine is designed to facilitate rapid tactical reloads."
+	cost = PAYCHECK_HARD * 6
+	contains = list(/obj/item/ammo_box/magazine/wt550m9)
+
 /datum/supply_pack/goody/thermal_single
 	name = "Thermal Pistol Holster Single-Pack"
 	desc = "Contains twinned thermal pistols in a holster, ready for use in the field."

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -282,12 +282,11 @@
 
 /datum/supply_pack/security/ammo
 	name = "Ammo Crate"
-	desc = "Contains three boxes of beanbag shotgun shells, three boxes of rubbershot shotgun shells and one of each special .38 speedloarders. Requires Security access to open."
+	desc = "Contains two 20-round magazines for the WT-550 Auto Rifle, three boxes of rubber ammo and special .38 speedloarders. Requires Security access to open."
 	cost = CARGO_CRATE_VALUE * 8
 	access_view = ACCESS_ARMORY
-	contains = list(/obj/item/storage/box/beanbag,
-					/obj/item/storage/box/beanbag,
-					/obj/item/storage/box/beanbag,
+	contains = list(/obj/item/ammo_box/magazine/wt550m9,
+					/obj/item/ammo_box/magazine/wt550m9,
 					/obj/item/storage/box/rubbershot,
 					/obj/item/storage/box/rubbershot,
 					/obj/item/storage/box/rubbershot,
@@ -639,10 +638,27 @@
 					/obj/item/clothing/gloves/tackler/combat)
 	crate_name = "swat crate"
 
+/datum/supply_pack/security/armory/wt550
+	name = "WT-550 Auto Rifle Crate"
+	desc = "Contains two high-powered, semiautomatic rifles chambered in 4.6x30mm. Requires Armory access to open."
+	contains = list(/obj/item/gun/ballistic/automatic/wt550,
+					/obj/item/gun/ballistic/automatic/wt550)
+	crate_name = "wt-550 auto rifle crate"
+
+/datum/supply_pack/security/armory/wt550ammo
+	name = "WT-550 Standard Ammo Crate"
+	desc = "Contains four 20-round magazine for the WT-550 Auto Rifle. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
+	cost = CARGO_CRATE_VALUE * 3.5
+	contains = list(/obj/item/ammo_box/magazine/wt550m9,
+					/obj/item/ammo_box/magazine/wt550m9,
+					/obj/item/ammo_box/magazine/wt550m9,
+					/obj/item/ammo_box/magazine/wt550m9)
+	crate_name = "wt-550 standard ammo crate"
+
 /datum/supply_pack/security/armory/thermal
 	name = "Thermal Pistol Crate"
 	desc = "Contains a pair of holsters each with two experimental thermal pistols, using nanites as the basis for their ammo. Requires Armory access to open."
-	cost = CARGO_CRATE_VALUE * 7
+	cost = CARGO_CRATE_VALUE * 3.5
 	contains = list(/obj/item/storage/belt/holster/thermal,
 					/obj/item/storage/belt/holster/thermal)
 	crate_name = "thermal pistol crate"

--- a/code/modules/projectiles/boxes_magazines/external/smg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/smg.dm
@@ -4,7 +4,8 @@
 	base_icon_state = "46x30mmt"
 	ammo_type = /obj/item/ammo_casing/c46x30mm
 	caliber = CALIBER_46X30MM
-	max_ammo = 20
+	max_ammo = 15
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/ammo_box/magazine/wt550m9/update_icon_state()
 	. = ..()

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -19,18 +19,20 @@
 
 /obj/projectile/bullet/c46x30mm
 	name = "4.6x30mm bullet"
-	damage = 20
+	damage = 16
+	armour_penetration = 10
 	wound_bonus = -5
-	bare_wound_bonus = 5
+	bare_wound_bonus = 2
 	embed_falloff_tile = -4
 
 /obj/projectile/bullet/c46x30mm/ap
 	name = "4.6x30mm armor-piercing bullet"
-	damage = 15
+	damage = 13
 	armour_penetration = 40
 	embedding = null
 
 /obj/projectile/bullet/incendiary/c46x30mm
 	name = "4.6x30mm incendiary bullet"
-	damage = 10
+	damage = 9
+	armour_penetration = 5
 	fire_stacks = 1

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -265,6 +265,34 @@
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
+//WT550 Mags
+
+/datum/design/mag_oldsmg
+	name = "WT-550 Auto Gun Magazine (4.6x30mm)"
+	desc = "A 20 round magazine for the out of date security WT-550 Auto Rifle"
+	id = "mag_oldsmg"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 4000)
+	build_path = /obj/item/ammo_box/magazine/wt550m9
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/mag_oldsmg/ap_mag
+	name = "WT-550 Auto Gun Armour Piercing Magazine (4.6x30mm AP)"
+	desc = "A 20 round armour piercing magazine for the out of date security WT-550 Auto Rifle"
+	id = "mag_oldsmg_ap"
+	materials = list(/datum/material/iron = 6000, /datum/material/silver = 600)
+	build_path = /obj/item/ammo_box/magazine/wt550m9/wtap
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/mag_oldsmg/ic_mag
+	name = "WT-550 Auto Gun Incendiary Magazine (4.6x30mm IC)"
+	desc = "A 20 round armour piercing magazine for the out of date security WT-550 Auto Rifle"
+	id = "mag_oldsmg_ic"
+	materials = list(/datum/material/iron = 6000, /datum/material/silver = 600, /datum/material/glass = 1000)
+	build_path = /obj/item/ammo_box/magazine/wt550m9/wtic
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
 /datum/design/stunshell
 	name = "Stun Shell"
 	desc = "A stunning shell for a shotgun."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1418,11 +1418,23 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	required_experiments = list(/datum/experiment/explosion/maxcap)
 
+/datum/techweb_node/ballistic_weapons
+	id = "ballistic_weapons"
+	display_name = "Ballistic Weaponry"
+	description = "This isn't research... This is reverse-engineering!"
+	prereq_ids = list("weaponry")
+	design_ids = list(
+		"mag_oldsmg",
+		"mag_oldsmg_ap",
+		"mag_oldsmg_ic",
+	)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+
 /datum/techweb_node/exotic_ammo
 	id = "exotic_ammo"
 	display_name = "Exotic Ammunition"
 	description = "They won't know what hit em."
-	prereq_ids = list("weaponry")
+	prereq_ids = list("adv_weaponry")
 	design_ids = list(
 		"c38_hotshot",
 		"c38_iceblox",
@@ -1721,7 +1733,7 @@
 	id = "mecha_tools"
 	display_name = "Exosuit Weapon (LBX AC 10 \"Scattershot\")"
 	description = "An advanced piece of mech weaponry"
-	prereq_ids = list("exotic_ammo")
+	prereq_ids = list("ballistic_weapons")
 	design_ids = list(
 		"mech_scattershot",
 		"mech_scattershot_ammo",
@@ -1732,7 +1744,7 @@
 	id = "mech_carbine"
 	display_name = "Exosuit Weapon (FNX-99 \"Hades\" Carbine)"
 	description = "An advanced piece of mech weaponry"
-	prereq_ids = list("exotic_ammo")
+	prereq_ids = list("ballistic_weapons")
 	design_ids = list(
 		"mech_carbine",
 		"mech_carbine_ammo",
@@ -1846,7 +1858,7 @@
 	id = "mech_lmg"
 	display_name = "Exosuit Weapon (\"Ultra AC 2\" LMG)"
 	description = "An advanced piece of mech weaponry"
-	prereq_ids = list("exotic_ammo")
+	prereq_ids = list("ballistic_weapons")
 	design_ids = list(
 		"mech_lmg",
 		"mech_lmg_ammo",


### PR DESCRIPTION
## About The Pull Request

Cette PR rajoute le WT-500 au Cargo qui a été supprimé dans la PR suivante ([#64280](https://github.com/tgstation/tgstation/pull/64280)), et réajuste quelque stats des Thermal Pistols ajoutés par cette même PR.

## Why It's Good For The Game

Le WT-500 est une arme qui est moyenne comparée a d'autres solutions, mais avoir une option balistique reste très importante contre les protections laser, comme le bouclier des nukies/ERT.
Les Thermal Pistols est une idée qui sur le papier est très bonne et intéressante, mais qui fonctionne plutôt mal en pratique : Le prix est exorbitant, ils sont a charge (donc il faut aller sur un chargeur très vite) il sont bulky et le holster l'est également. Cette PR a été une excuse pour stealth-nerf le Cargo. 
Cependant, je désire voir comment les Thermal Pistols peuvent changer pour le meilleur (ils remplient une niche sympatique), donc je les supprime pas dans cette PR.

Edit : Suite a la requête de GbFree, j'ai nerfé le WT-500 en augmentant la taille de chargeurs de Tiny a Small, et leur nombre de balles de 20 a 15. 

## Changelog

:cl:
add: WT-500 et les munitions sont de nouveau achetable au Cargo
add: Les technologies et recherches par rapport au WT-500 on été remises en Science
balance: Le prix des Thermal Pistols a été reduit par 2
balance: Le holster des Thermal Pistols n'est plus bulky
balance: Chargeurs WT-500 sont maintenant small, et ne contiennent plus que 15 balles
/:cl:

