### PR TITLE
Traitor rebalance

### DIFF
--- a/_maps/templates/battlecruiser_starfury.dmm
+++ b/_maps/templates/battlecruiser_starfury.dmm
@@ -4009,9 +4009,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/mob_spawn/ghost_role/human/syndicate/battlecruiser/assault{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/dark,
 /area/shuttle/sbc_starfury)
@@ -4724,6 +4721,13 @@
 	},
 /turf/open/floor/pod/dark,
 /area/shuttle/sbc_starfury)
+"qW" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/sbc_starfury)
 "rf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -5099,9 +5103,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
-	},
-/obj/effect/mob_spawn/ghost_role/human/syndicate/battlecruiser{
-	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/shuttle/sbc_starfury)
@@ -6570,13 +6571,13 @@ eO
 eR
 fe
 ae
-sh
-sh
+gO
+gO
 ae
 hh
 hG
 ae
-sh
+gO
 sh
 ae
 iV
@@ -6709,7 +6710,7 @@ eR
 wc
 ae
 ir
-ir
+hW
 ae
 hj
 hI
@@ -7192,7 +7193,7 @@ ST
 fl
 ae
 gx
-gx
+qW
 ae
 hq
 hP

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -206,6 +206,12 @@ GLOBAL_LIST_INIT(ai_employers, list(
 /// The dimensions of the antagonist preview icon. Will be scaled to this size.
 #define ANTAGONIST_PREVIEW_ICON_SIZE 96
 
+/// Defines for the various hack results.
+#define HACK_PIRATE "Pirates"
+#define HACK_FUGITIVES "Fugitives"
+#define HACK_SLEEPER "Sleeper Agents"
+#define HACK_THREAT "Threat Boost"
+
 // Defines for objective items to determine what they can appear in
 /// Can appear in everything
 #define OBJECTIVE_ITEM_TYPE_NORMAL "normal"

--- a/code/controllers/subsystem/traitor.dm
+++ b/code/controllers/subsystem/traitor.dm
@@ -19,12 +19,12 @@ SUBSYSTEM_DEF(traitor)
 	var/configuration_data = list()
 
 	/// The coefficient multiplied by the current_global_progression for new joining traitors to calculate their progression
-	var/newjoin_progression_coeff = 0.6
+	var/newjoin_progression_coeff = 0.75
 	/// The current progression that all traitors should be at in the round
 	var/current_global_progression = 0
 	/// The amount of deviance from the current global progression before you start getting 2x the current scaling or no scaling at all
 	/// Also affects objectives, so -50% progress reduction or 50% progress boost.
-	var/progression_scaling_deviance = 20 MINUTES
+	var/progression_scaling_deviance = 30 MINUTES
 	/// The current uplink handlers being managed
 	var/list/datum/uplink_handler/uplink_handlers = list()
 	/// The current scaling per minute of progression. Has a maximum value of 1 MINUTES.

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -763,20 +763,15 @@
 /obj/machinery/computer/communications/proc/add_message(datum/comm_message/new_message)
 	LAZYADD(messages, new_message)
 
-/// Defines for the various hack results.
-#define HACK_PIRATE "Pirates"
-#define HACK_FUGITIVES "Fugitives"
-#define HACK_SLEEPER "Sleeper Agents"
-#define HACK_THREAT "Threat Boost"
 
 /// The minimum number of ghosts / observers to have the chance of spawning pirates.
-#define MIN_GHOSTS_FOR_PIRATES 4
+#define MIN_GHOSTS_FOR_PIRATES 3
 /// The minimum number of ghosts / observers to have the chance of spawning fugitives.
-#define MIN_GHOSTS_FOR_FUGITIVES 6
+#define MIN_GHOSTS_FOR_FUGITIVES 4
 /// The maximum percentage of the population to be ghosts before we no longer have the chance of spawning Sleeper Agents.
-#define MAX_PERCENT_GHOSTS_FOR_SLEEPER 0.2
+#define MAX_PERCENT_GHOSTS_FOR_SLEEPER 0.3
 /// The amount of threat injected by a hack, if chosen.
-#define HACK_THREAT_INJECTION_AMOUNT 15
+#define HACK_THREAT_INJECTION_AMOUNT 25
 
 /*
  * The communications console hack,
@@ -802,7 +797,9 @@
 	// If less than a certain percent of the population is ghosts, consider sleeper agents
 	if(num_ghosts < (length(GLOB.clients) * MAX_PERCENT_GHOSTS_FOR_SLEEPER))
 		hack_options += HACK_SLEEPER
+	hack_console_custom(hacker, hack_options)
 
+/obj/machinery/computer/communications/proc/hack_console_custom(mob/living/hacker, var/list/hack_options)
 	var/picked_option = pick(hack_options)
 	message_admins("[ADMIN_LOOKUPFLW(hacker)] hacked a [name] located at [ADMIN_VERBOSEJMP(src)], resulting in: [picked_option]!")
 	hacker.log_message("hacked a communications console, resulting in: [picked_option].", LOG_GAME, log_globally = TRUE)
@@ -868,10 +865,6 @@
 					"[command_name()] High-Priority Update"
 					)
 
-#undef HACK_PIRATE
-#undef HACK_FUGITIVES
-#undef HACK_SLEEPER
-#undef HACK_THREAT
 
 #undef MIN_GHOSTS_FOR_PIRATES
 #undef MIN_GHOSTS_FOR_FUGITIVES

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -153,7 +153,7 @@
 	name = "traitor progression"
 	explanation_text = "Become a living legend by getting a total of %REPUTATION% reputation points"
 
-	var/possible_range = list(40 MINUTES, 90 MINUTES)
+	var/possible_range = list(90 MINUTES, 130 MINUTES)
 	var/required_total_progression_points
 
 /datum/objective/traitor_progression/New(text)
@@ -177,7 +177,7 @@
 	name = "traitor objective"
 	explanation_text = "Complete objectives colletively worth more than %REPUTATION% reputation points"
 
-	var/possible_range = list(20 MINUTES, 30 MINUTES)
+	var/possible_range = list(25 MINUTES, 45 MINUTES)
 	var/required_progression_in_objectives
 
 /datum/objective/traitor_objectives/New(text)

--- a/code/modules/antagonists/traitor/objectives/assassination.dm
+++ b/code/modules/antagonists/traitor/objectives/assassination.dm
@@ -19,10 +19,10 @@
 
 	abstract_type = /datum/traitor_objective/assassinate
 
-	progression_minimum = 30 MINUTES
+	progression_minimum = 27 MINUTES
 
-	progression_reward = 2 MINUTES
-	telecrystal_reward = list(1, 2)
+	progression_reward = list(6 MINUTES, 12 MINUTES)
+	telecrystal_reward = list(2, 3)
 
 	// The code below is for limiting how often you can get this objective. You will get this objective at a maximum of maximum_objectives_in_period every objective_period
 	/// The objective period at which we consider if it is an 'objective'. Set to 0 to accept all objectives.
@@ -51,7 +51,7 @@
 	var/obj/item/paper/calling_card/card
 
 /datum/traitor_objective/assassinate/calling_card/heads_of_staff
-	progression_reward = 4 MINUTES
+	progression_reward = list(8 MINUTES, 15 MINUTES)
 	telecrystal_reward = list(3, 4)
 
 	heads_of_staff = TRUE
@@ -66,7 +66,7 @@
 	var/obj/item/bodypart/head/behead_goal
 
 /datum/traitor_objective/assassinate/behead/heads_of_staff
-	progression_reward = 4 MINUTES
+	progression_reward = list(8 MINUTES, 15 MINUTES)
 	telecrystal_reward = list(3, 4)
 
 	heads_of_staff = TRUE
@@ -170,13 +170,6 @@
 	)
 
 /datum/traitor_objective/assassinate/generate_objective(datum/mind/generating_for, list/possible_duplicates)
-
-	var/parent_type = type2parent(type)
-	//don't roll head of staff types if you haven't completed the normal version
-	if(heads_of_staff && !handler.get_completion_count(parent_type))
-		// Locked if they don't have any of the risky bug room objective completed
-		return FALSE
-
 	var/list/possible_targets = list()
 	var/try_target_late_joiners = FALSE
 	if(generating_for.late_joiner)

--- a/code/modules/antagonists/traitor/objectives/assassination.dm
+++ b/code/modules/antagonists/traitor/objectives/assassination.dm
@@ -19,16 +19,16 @@
 
 	abstract_type = /datum/traitor_objective/assassinate
 
-	progression_minimum = 27 MINUTES
+	progression_minimum = 26 MINUTES
 
-	progression_reward = list(6 MINUTES, 12 MINUTES)
+	progression_reward = list(6 MINUTES, 14 MINUTES)
 	telecrystal_reward = list(2, 3)
 
 	// The code below is for limiting how often you can get this objective. You will get this objective at a maximum of maximum_objectives_in_period every objective_period
 	/// The objective period at which we consider if it is an 'objective'. Set to 0 to accept all objectives.
-	var/objective_period = 15 MINUTES
+	var/objective_period = 30 MINUTES
 	/// The maximum number of objectives we can get within this period.
-	var/maximum_objectives_in_period = 3
+	var/maximum_objectives_in_period = 2
 
 	/**
 	 * Makes the objective only set heads as targets when true, and block them from being targets when false.
@@ -51,7 +51,8 @@
 	var/obj/item/paper/calling_card/card
 
 /datum/traitor_objective/assassinate/calling_card/heads_of_staff
-	progression_reward = list(8 MINUTES, 15 MINUTES)
+	progression_minimum = 40 MINUTES
+	progression_reward = list(8 MINUTES, 20 MINUTES)
 	telecrystal_reward = list(3, 4)
 
 	heads_of_staff = TRUE
@@ -66,7 +67,8 @@
 	var/obj/item/bodypart/head/behead_goal
 
 /datum/traitor_objective/assassinate/behead/heads_of_staff
-	progression_reward = list(8 MINUTES, 15 MINUTES)
+	progression_minimum = 40 MINUTES
+	progression_reward = list(8 MINUTES, 20 MINUTES)
 	telecrystal_reward = list(3, 4)
 
 	heads_of_staff = TRUE
@@ -189,10 +191,10 @@
 			continue
 		//removes heads of staff from being targets from non heads of staff assassinations, and vice versa
 		if(heads_of_staff)
-			if(!(possible_target.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
+			if(!(possible_target.assigned_role.departments_bitflags & (DEPARTMENT_BITFLAG_SECURITY|DEPARTMENT_BITFLAG_COMMAND)))
 				continue
 		else
-			if((possible_target.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
+			if((possible_target.assigned_role.departments_bitflags & (DEPARTMENT_BITFLAG_SECURITY|DEPARTMENT_BITFLAG_COMMAND)))
 				continue
 		possible_targets += possible_target
 	for(var/datum/traitor_objective/assassinate/objective as anything in possible_duplicates)

--- a/code/modules/antagonists/traitor/objectives/bug_room.dm
+++ b/code/modules/antagonists/traitor/objectives/bug_room.dm
@@ -14,7 +14,7 @@
 		Remember, planting the bug may leave behind fibers and fingerprints - \
 		be sure to clean it off with soap (or similar) to be safe!"
 
-	progression_reward = list(2 MINUTES, 8 MINUTES)
+	progression_reward = list(2 MINUTES, 6 MINUTES)
 	telecrystal_reward = list(0, 1)
 
 	progression_maximum = 30 MINUTES
@@ -37,7 +37,7 @@
 	applicable_heads = list(
 		JOB_CAPTAIN = /area/command/heads_quarters/captain,
 	)
-	progression_reward = list(5 MINUTES, 10 MINUTES)
+	progression_reward = list(4 MINUTES, 8 MINUTES)
 	telecrystal_reward = list(1, 2)
 	requires_head_as_supervisor = FALSE
 
@@ -47,7 +47,7 @@
 	applicable_heads = list(
 		JOB_HEAD_OF_SECURITY = /area/command/heads_quarters/hos,
 	)
-	progression_reward = list(10 MINUTES, 15 MINUTES)
+	progression_reward = list(8 MINUTES, 12 MINUTES)
 	telecrystal_reward = list(2, 3)
 	requires_head_as_supervisor = FALSE
 

--- a/code/modules/antagonists/traitor/objectives/destroy_item.dm
+++ b/code/modules/antagonists/traitor/objectives/destroy_item.dm
@@ -19,7 +19,7 @@
 /datum/traitor_objective/destroy_item/low_risk
 	progression_minimum = 10 MINUTES
 	progression_maximum = 35 MINUTES
-	progression_reward = list(5 MINUTES, 10 MINUTES)
+	progression_reward = list(4 MINUTES, 8 MINUTES)
 	telecrystal_reward = 1
 
 	possible_items = list(
@@ -30,8 +30,8 @@
 
 /datum/traitor_objective/destroy_item/very_risky
 	progression_minimum = 40 MINUTES
-	progression_reward = 15 MINUTES
-	telecrystal_reward = 3
+	progression_reward = list(10 MINUTES, 16 MINUTES)
+	telecrystal_reward = list(1, 3)
 
 	possible_items = list(
 		/datum/objective_item/steal/blackbox,

--- a/code/modules/antagonists/traitor/objectives/final_objective/battlecruiser.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/battlecruiser.dm
@@ -1,5 +1,5 @@
 /// The minimum number of ghosts and observers needed before handing out battlecruiser objectives.
-#define MIN_GHOSTS_FOR_BATTLECRUISER 8
+#define MIN_GHOSTS_FOR_BATTLECRUISER 3
 
 /datum/traitor_objective/final/battlecruiser
 	name = "Reveal Station Coordinates to nearby Syndicate Battlecruiser"

--- a/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
@@ -8,9 +8,9 @@
 
 /datum/traitor_objective/final
 	abstract_type = /datum/traitor_objective/final
-	progression_minimum = 140 MINUTES
+	progression_minimum = 125 MINUTES
 
-	var/progression_points_in_objectives = 20 MINUTES
+	var/progression_points_in_objectives = 25 MINUTES
 
 /// Determines if this final objective can be taken. Should be put into every final objective's generate function.
 /datum/traitor_objective/final/proc/can_take_final_objective()

--- a/code/modules/antagonists/traitor/objectives/final_objective/lone_ops.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/lone_ops.dm
@@ -1,0 +1,123 @@
+/// The minimum number of ghosts and observers needed before handing out battlecruiser objectives.
+#define MIN_GHOSTS_FOR_LONE 1
+
+/datum/traitor_objective/final/lone_ops
+	name = "Set beacons for a lone ops drop"
+	description = "Insert special beacons card to two of the solar panel's trackers to \
+	allow a syndicate operative drop. You may want to make your syndicate status known to \
+	him when he arrive - your goal will then be to destroy the station."
+
+	/// Checks whether we have sent the card to the traitor yet.
+	var/sent_accesscard = FALSE
+
+/datum/traitor_objective/final/lone_ops/generate_objective(datum/mind/generating_for, list/possible_duplicates)
+	if(!can_take_final_objective())
+		return FALSE
+	// Check how many observers + ghosts (dead players) we have.
+	// If there's not a ton of observers and ghosts to populate the battlecruiser,
+	// We won't bother giving the objective out.
+	var/num_ghosts = length(GLOB.current_observers_list) + length(GLOB.dead_player_list)
+	if(num_ghosts < MIN_GHOSTS_FOR_LONE)
+		return FALSE
+	return TRUE
+
+/datum/traitor_objective/final/lone_ops/on_objective_taken(mob/user)
+	. = ..()
+
+
+/datum/traitor_objective/final/lone_ops/generate_ui_buttons(mob/user)
+	var/list/buttons = list()
+	if(!sent_accesscard)
+		buttons += add_ui_button("", "Pressing this will materialize beacons, that you can use on solar panel's trackers.", "phone", "card")
+	return buttons
+
+/datum/traitor_objective/final/lone_ops/ui_perform_action(mob/living/user, action)
+	. = ..()
+	switch(action)
+		if("card")
+			if(sent_accesscard)
+				return
+			sent_accesscard = TRUE
+			var/obj/item/card/emag/lone_ops_obj/emag_card = new()
+			podspawn(list(
+				"target" = get_turf(user),
+				"style" = STYLE_SYNDICATE,
+				"spawn" = emag_card,
+			))
+
+
+
+/datum/antagonist/nukeop/lone/ally
+	always_new_team = FALSE
+
+/datum/antagonist/nukeop/lone/ally/on_gain()
+	forge_objectives()
+	memorize_code()
+	add_team_hud(owner.current, /datum/antagonist/nukeop)
+
+/obj/item/card/emag/lone_ops_obj
+	name = "lone ops beacon emag card"
+	desc = "An ominous card that contains the location of the station, and when applied to a solar panel array tracker the ability to stealthly start a syndicate lone operative drop."
+	icon_state = "bug"
+	icon_state = "battlecruisercaller"
+	worn_icon_state = "battlecruisercaller"
+	///whether we have called the battlecruiser
+	var/used = 0
+
+/obj/item/card/emag/lone_ops_obj/proc/use_charge(mob/user)
+	used = used + 1
+	if (used<2)
+		to_chat(user, span_boldwarning("One solar panel array subverted. We need to subvert another one."))
+	if (used == 2)
+		start_mission(user)
+		qdel(src)
+
+/obj/item/card/emag/lone_ops_obj/examine(mob/user)
+	. = ..()
+	. += span_notice("It can only be used on the solar panel trackers.")
+
+/obj/item/card/emag/lone_ops_obj/can_emag(atom/target, mob/user)
+	if(!istype(target, /obj/machinery/power/tracker))
+		to_chat(user, span_warning("[src] is unable to interface with this. It only seems to interface with solar array's solar tracker."))
+		return FALSE
+	return TRUE
+
+/obj/item/card/emag/lone_ops_obj/proc/start_mission(mob/user)
+	to_chat(user, span_boldwarning("Station found. Stealth drop pod in final aproach."))
+	var/nukie_drop_success = spawn_ops()
+	user.mind.add_antag_datum(/datum/antagonist/nukeop/lone/ally)
+	if(nukie_drop_success)
+		to_chat(user, span_boldwarning("The operation is a go! Time to join with the dropped operative and get that nuke disk."))
+	else
+		to_chat(user, span_boldwarning("The drop was a failure! The operative in probably dead or incapacited. You have be given 10 aditional TC. Try to cause the self destruction of the station alone."))
+		user.mind.find_syndicate_uplink().add_telecrystals(10)
+	
+/obj/item/card/emag/lone_ops_obj/proc/spawn_ops()
+	var/list/candidates = poll_ghost_candidates("Do you wish to be considered for the special role of Lone Operative'?", ROLE_OPERATIVE)
+
+	if(!candidates.len)
+		return FALSE
+	shuffle_inplace(candidates)
+
+	var/mob/dead/selected = pick_n_take(candidates)
+
+	var/list/spawn_locs = list()
+	for(var/obj/effect/landmark/carpspawn/L in GLOB.landmarks_list)
+		spawn_locs += L.loc
+	if(!spawn_locs.len)
+		return FALSE
+
+	var/mob/living/carbon/human/operative = new(pick(spawn_locs))
+	operative.randomize_human_appearance(~RANDOMIZE_SPECIES)
+	operative.dna.update_dna_identity()
+	var/datum/mind/Mind = new /datum/mind(selected.key)
+	Mind.set_assigned_role(SSjob.GetJobType(/datum/job/lone_operative))
+	Mind.special_role = ROLE_LONE_OPERATIVE
+	Mind.active = TRUE
+	Mind.transfer_to(operative)
+	Mind.add_antag_datum(/datum/antagonist/nukeop/lone)
+
+	message_admins("[ADMIN_LOOKUPFLW(operative)] has been made into lone operative by a mission.")
+	log_game("[key_name(operative)] was spawned as a lone operative by a mission.")
+	return TRUE
+#undef MIN_GHOSTS_FOR_LONE

--- a/code/modules/antagonists/traitor/objectives/final_objective/pirates.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/pirates.dm
@@ -2,12 +2,20 @@
 
 /datum/traitor_objective/final/hack_comm_console_pirates
 	name = "Hack a communication console to send the station coordinates to a nearby pirate ship."
-	description = "Right click on a communication console to begin the hacking process. Once started, the AI will know that you are hacking a communication console, so be ready to run or have yourself disguised to prevent being caught. This objective will invalidate itself if another traitor completes it first."
+	description = "Right click on a communication console to begin the hacking process. Once started, \
+	the AI will know that you are hacking a communication console, so be ready to run or have yourself \
+	disguised to prevent being caught. The pirates are not aware of your presence on the station."
 
 /datum/traitor_objective/final/hack_comm_console_pirates/generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	if(!can_take_final_objective())
 		return
 	if(SStraitor.get_taken_count(/datum/traitor_objective/final/hack_comm_console_pirates) > 0)
+		return FALSE
+	// Check how many observers + ghosts (dead players) we have.
+	// If there's not a ton of observers and ghosts to populate the battlecruiser,
+	// We won't bother giving the objective out.
+	var/num_ghosts = length(GLOB.current_observers_list) + length(GLOB.dead_player_list)
+	if(num_ghosts < MIN_GHOSTS_FOR_PIRATES)
 		return FALSE
 	AddComponent(/datum/component/traitor_objective_mind_tracker, generating_for, \
 		signals = list(COMSIG_HUMAN_EARLY_UNARMED_ATTACK = .proc/on_unarmed_attack))

--- a/code/modules/antagonists/traitor/objectives/final_objective/pirates.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/pirates.dm
@@ -1,0 +1,40 @@
+#define MIN_GHOSTS_FOR_PIRATES 2
+
+/datum/traitor_objective/final/hack_comm_console_pirates
+	name = "Hack a communication console to send the station coordinates to a nearby pirate ship."
+	description = "Right click on a communication console to begin the hacking process. Once started, the AI will know that you are hacking a communication console, so be ready to run or have yourself disguised to prevent being caught. This objective will invalidate itself if another traitor completes it first."
+
+/datum/traitor_objective/final/hack_comm_console_pirates/generate_objective(datum/mind/generating_for, list/possible_duplicates)
+	if(!can_take_final_objective())
+		return
+	if(SStraitor.get_taken_count(/datum/traitor_objective/final/hack_comm_console_pirates) > 0)
+		return FALSE
+	AddComponent(/datum/component/traitor_objective_mind_tracker, generating_for, \
+		signals = list(COMSIG_HUMAN_EARLY_UNARMED_ATTACK = .proc/on_unarmed_attack))
+	RegisterSignal(generating_for, COMSIG_GLOB_TRAITOR_OBJECTIVE_COMPLETED, .proc/on_global_obj_completed)
+	return TRUE
+
+/datum/traitor_objective/final/hack_comm_console_pirates/proc/on_global_obj_completed(datum/source, datum/traitor_objective/objective)
+	SIGNAL_HANDLER
+	if(istype(objective, /datum/traitor_objective/final/hack_comm_console_pirates))
+		fail_objective()
+
+/datum/traitor_objective/final/hack_comm_console_pirates/proc/on_unarmed_attack(mob/user, obj/machinery/computer/communications/target, proximity_flag, modifiers)
+	SIGNAL_HANDLER
+	if(!proximity_flag)
+		return
+	if(!modifiers[RIGHT_CLICK])
+		return
+	if(!istype(target))
+		return
+	INVOKE_ASYNC(src, .proc/begin_hack, user, target)
+	return COMPONENT_CANCEL_ATTACK_CHAIN
+
+/datum/traitor_objective/final/hack_comm_console_pirates/proc/begin_hack(mob/user, obj/machinery/computer/communications/target)
+	target.AI_notify_hack()
+	if(!do_after(user, 30 SECONDS, target))
+		return
+	succeed_objective()
+	target.hack_console_custom(user, list(HACK_PIRATE))
+
+#undef MIN_GHOSTS_FOR_PIRATES

--- a/code/modules/antagonists/traitor/objectives/hack_comm_console.dm
+++ b/code/modules/antagonists/traitor/objectives/hack_comm_console.dm
@@ -5,12 +5,12 @@
 	)
 
 /datum/traitor_objective/hack_comm_console
-	name = "Hack a communication console to summon an unknown threat to the station"
+	name = "Hack a communication console to activate a syndicate sleeper cell in the station"
 	description = "Right click on a communication console to begin the hacking process. Once started, the AI will know that you are hacking a communication console, so be ready to run or have yourself disguised to prevent being caught. This objective will invalidate itself if another traitor completes it first."
 
 	progression_minimum = 60 MINUTES
-	progression_reward = list(30 MINUTES, 40 MINUTES)
-	telecrystal_reward = list(7, 12)
+	progression_reward = list(10 MINUTES, 20 MINUTES)
+	telecrystal_reward = list(3, 6)
 
 	var/progression_objectives_minimum = 20 MINUTES
 
@@ -45,4 +45,4 @@
 	if(!do_after(user, 30 SECONDS, target))
 		return
 	succeed_objective()
-	target.hack_console(user)
+	target.hack_console_custom(user, list(HACK_THREAT, HACK_SLEEPER))

--- a/code/modules/antagonists/traitor/objectives/kill_pet.dm
+++ b/code/modules/antagonists/traitor/objectives/kill_pet.dm
@@ -11,9 +11,9 @@
 /datum/traitor_objective/kill_pet
 	name = "Kill the %DEPARTMENT HEAD%'s beloved %PET%"
 	description = "The %DEPARTMENT HEAD% has particularly annoyed us by sending us spam emails and we want their %PET% dead to show them what happens when they cross us. "
-	telecrystal_reward = list(1, 2)
+	telecrystal_reward = list(0, 2)
 
-	progression_reward = list(3 MINUTES, 6 MINUTES)
+	progression_reward = list(2 MINUTES, 5 MINUTES)
 
 	/// Possible heads mapped to their pet type. Can be a list of possible pets
 	var/list/possible_heads = list(
@@ -33,14 +33,14 @@
 	var/mob/living/target_pet
 
 /datum/traitor_objective/kill_pet/medium_risk
-	progression_minimum = 10 MINUTES
-	progression_reward = list(5 MINUTES, 8 MINUTES)
+	progression_minimum = 5 MINUTES
+	progression_reward = list(3 MINUTES, 8 MINUTES)
 	limited_to_department_head = FALSE
 
 /datum/traitor_objective/kill_pet/high_risk
 	progression_minimum = 25 MINUTES
-	progression_reward = list(14 MINUTES, 18 MINUTES)
-	telecrystal_reward = list(2, 3)
+	progression_reward = list(8 MINUTES, 12 MINUTES)
+	telecrystal_reward = list(1, 2)
 
 	limited_to_department_head = FALSE
 	possible_heads = list(

--- a/code/modules/antagonists/traitor/objectives/sleeper_protocol.dm
+++ b/code/modules/antagonists/traitor/objectives/sleeper_protocol.dm
@@ -10,7 +10,7 @@
 	description = "Use the button below to materialize a surgery disk in your hand, where you'll then be able to perform the sleeper protocol on a crewmember. If the disk gets destroyed, the objective will fail. This will only work on living and sentient crewmembers."
 
 	progression_reward = list(8 MINUTES, 15 MINUTES)
-	telecrystal_reward = 0
+	telecrystal_reward = list(0, 1)
 
 	var/list/limited_to = list(
 		JOB_CHIEF_MEDICAL_OFFICER,
@@ -47,7 +47,8 @@
 /datum/traitor_objective/sleeper_protocol/generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	var/datum/job/job = generating_for.assigned_role
 	if(!(job.title in limited_to))
-		return FALSE
+		if(prob(90))
+			return FALSE
 	AddComponent(/datum/component/traitor_objective_mind_tracker, generating_for, \
 		signals = list(COMSIG_MOB_SURGERY_STEP_SUCCESS = .proc/on_surgery_success))
 	return TRUE

--- a/code/modules/antagonists/traitor/objectives/smuggling.dm
+++ b/code/modules/antagonists/traitor/objectives/smuggling.dm
@@ -11,7 +11,7 @@
 	You will instantly fail this objective if anyone else picks up your contraband. If you fail, you are liable for the costs \
 	of the smuggling item."
 
-	progression_reward = list(5 MINUTES, 9 MINUTES)
+	progression_reward = list(4 MINUTES, 9 MINUTES)
 	telecrystal_reward = list(0, 1)
 
 	///area type the objective owner must be in to recieve the contraband

--- a/code/modules/antagonists/traitor/objectives/steal.dm
+++ b/code/modules/antagonists/traitor/objectives/steal.dm
@@ -67,7 +67,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	/// Any special equipment that may be needed
 	var/list/special_equipment
 	/// Telecrystal reward increase per unit of time.
-	var/minutes_per_telecrystal = 3
+	var/minutes_per_telecrystal = 7
 
 	abstract_type = /datum/traitor_objective/steal_item
 
@@ -75,7 +75,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	progression_minimum = 4 MINUTES
 	progression_maximum = 25 MINUTES
 
-	progression_reward = list(3 MINUTES, 7 MINUTES)
+	progression_reward = list(3 MINUTES, 6 MINUTES)
 	telecrystal_reward = 0
 	possible_items = list(
 		/datum/objective_item/steal/low_risk/techboard/borgupload,
@@ -86,7 +86,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 /datum/traitor_objective/steal_item/low_risk
 	progression_minimum = 4 MINUTES
 	progression_maximum = 35 MINUTES
-	progression_reward = list(3 MINUTES, 7 MINUTES)
+	progression_reward = list(3 MINUTES, 6 MINUTES)
 	telecrystal_reward = 0
 
 	possible_items = list(
@@ -108,8 +108,8 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 
 /datum/traitor_objective/steal_item/risky
-	hold_time_required = list(4, 12)
-	minutes_per_telecrystal = 2.5
+	hold_time_required = list(4, 10)
+	minutes_per_telecrystal = 4
 	progression_minimum = 25 MINUTES
 	progression_reward = list(10 MINUTES, 15 MINUTES)
 	telecrystal_reward = list(1, 2)
@@ -123,7 +123,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 
 /datum/traitor_objective/steal_item/very_risky
 	hold_time_required = list(4, 10)
-	minutes_per_telecrystal = 2
+	minutes_per_telecrystal = 3
 	progression_minimum = 35 MINUTES
 	progression_reward = list(13 MINUTES, 18 MINUTES)
 	telecrystal_reward = list(1, 3)
@@ -136,11 +136,11 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 
 /datum/traitor_objective/steal_item/most_risky
-	hold_time_required = list(4, 10)
+	hold_time_required = list(3, 8)
 	minutes_per_telecrystal = 2
 	progression_minimum = 45 MINUTES
 	progression_reward = list(18 MINUTES, 25 MINUTES)
-	telecrystal_reward = list(2, 5)
+	telecrystal_reward = list(2, 4)
 
 	possible_items = list(
 		/datum/objective_item/steal/nukedisc,

--- a/code/modules/antagonists/traitor/objectives/steal.dm
+++ b/code/modules/antagonists/traitor/objectives/steal.dm
@@ -72,10 +72,10 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	abstract_type = /datum/traitor_objective/steal_item
 
 /datum/traitor_objective/steal_item/low_risk_cap
-	progression_minimum = 5 MINUTES
-	progression_maximum = 20 MINUTES
+	progression_minimum = 4 MINUTES
+	progression_maximum = 25 MINUTES
 
-	progression_reward = list(5 MINUTES, 10 MINUTES)
+	progression_reward = list(3 MINUTES, 7 MINUTES)
 	telecrystal_reward = 0
 	possible_items = list(
 		/datum/objective_item/steal/low_risk/techboard/borgupload,
@@ -84,9 +84,9 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 
 /datum/traitor_objective/steal_item/low_risk
-	progression_minimum = 10 MINUTES
+	progression_minimum = 4 MINUTES
 	progression_maximum = 35 MINUTES
-	progression_reward = list(5 MINUTES, 10 MINUTES)
+	progression_reward = list(3 MINUTES, 7 MINUTES)
 	telecrystal_reward = 0
 
 	possible_items = list(
@@ -95,8 +95,8 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 
 /datum/traitor_objective/steal_item/somewhat_risky
-	progression_minimum = 20 MINUTES
-	progression_reward = 5 MINUTES
+	progression_minimum = 15 MINUTES
+	progression_reward = list(3 MINUTES, 6 MINUTES)
 	telecrystal_reward = 1
 
 	possible_items = list(
@@ -108,9 +108,11 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 
 /datum/traitor_objective/steal_item/risky
-	progression_minimum = 30 MINUTES
-	progression_reward = 13 MINUTES
-	telecrystal_reward = 2
+	hold_time_required = list(4, 12)
+	minutes_per_telecrystal = 2.5
+	progression_minimum = 25 MINUTES
+	progression_reward = list(10 MINUTES, 15 MINUTES)
+	telecrystal_reward = list(1, 2)
 
 	possible_items = list(
 		/datum/objective_item/steal/reflector,
@@ -120,9 +122,11 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 
 /datum/traitor_objective/steal_item/very_risky
-	progression_minimum = 40 MINUTES
-	progression_reward = 17 MINUTES
-	telecrystal_reward = 3
+	hold_time_required = list(4, 10)
+	minutes_per_telecrystal = 2
+	progression_minimum = 35 MINUTES
+	progression_reward = list(13 MINUTES, 18 MINUTES)
+	telecrystal_reward = list(1, 3)
 
 	possible_items = list(
 		/datum/objective_item/steal/hoslaser,
@@ -132,9 +136,11 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 
 /datum/traitor_objective/steal_item/most_risky
-	progression_minimum = 50 MINUTES
-	progression_reward = 25 MINUTES
-	telecrystal_reward = 5
+	hold_time_required = list(4, 10)
+	minutes_per_telecrystal = 2
+	progression_minimum = 45 MINUTES
+	progression_reward = list(18 MINUTES, 25 MINUTES)
+	telecrystal_reward = list(2, 5)
 
 	possible_items = list(
 		/datum/objective_item/steal/nukedisc,

--- a/code/modules/power/tracker.dm
+++ b/code/modules/power/tracker.dm
@@ -83,6 +83,18 @@
 			new /obj/item/shard(src.loc)
 	qdel(src)
 
+/obj/machinery/power/tracker/emag_act(mob/user, obj/item/card/emag/emag_card)
+	if(obj_flags & EMAGGED)
+		return
+	if(istype(emag_card, /obj/item/card/emag/lone_ops_obj))
+		if(!user.mind?.has_antag_datum(/datum/antagonist/traitor))
+			to_chat(user, span_danger("You get the feeling this is a bad idea."))
+			return
+		var/obj/item/card/emag/lone_ops_obj/caller_card = emag_card
+		caller_card.use_charge(user)
+		obj_flags |= EMAGGED
+
+
 // Tracker Electronic
 
 /obj/item/electronics/tracker

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2137,6 +2137,7 @@
 #include "code\modules\antagonists\traitor\objectives\steal.dm"
 #include "code\modules\antagonists\traitor\objectives\final_objective\battlecruiser.dm"
 #include "code\modules\antagonists\traitor\objectives\final_objective\final_objective.dm"
+#include "code\modules\antagonists\traitor\objectives\final_objective\lone_ops.dm"
 #include "code\modules\antagonists\traitor\objectives\final_objective\pirates.dm"
 #include "code\modules\antagonists\traitor\objectives\final_objective\romerol.dm"
 #include "code\modules\antagonists\valentines\heartbreaker.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2137,6 +2137,7 @@
 #include "code\modules\antagonists\traitor\objectives\steal.dm"
 #include "code\modules\antagonists\traitor\objectives\final_objective\battlecruiser.dm"
 #include "code\modules\antagonists\traitor\objectives\final_objective\final_objective.dm"
+#include "code\modules\antagonists\traitor\objectives\final_objective\pirates.dm"
 #include "code\modules\antagonists\traitor\objectives\final_objective\romerol.dm"
 #include "code\modules\antagonists\valentines\heartbreaker.dm"
 #include "code\modules\antagonists\valentines\valentine.dm"


### PR DESCRIPTION
Ajoute 2 missions finales : vaisseau pirate, et not so lone ops.
Le mission finale croiseur nukies ne contient plus que 4 nukies.
Reduit légèrement la reputation necessaire pour debloquer la missions finale (pour rentrer dans notre format de 2h)
Augmente légèrement l'écart de réputation autorisé avant que les pénalités démarrent.
Reduit légèrement les récompenses de smissions de vols.
Augmente fortement les récompensent de missions meurtres.
Les missions meurtres risquées (les heads) sont maintenant disponibles sans avoir déjà accomplie une mission meurtre normales.
Les missions meurtres sur un membre de la securité sont maintenant considérées comme risquées (plus de récompense, plus tard dans la partie).
La mission normale hackage d'ordinateur de comms ne peut plus creer de pirates.