### PR TITLE
Réinsertion des tasers (+Rééquilibrage prix WT-500 / Thermals) 

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2947,6 +2947,9 @@
 /obj/structure/rack,
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
+/obj/item/gun/energy/taser,
+/obj/item/gun/energy/taser,
+/obj/item/gun/energy/taser,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "ajS" = (

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -1168,3 +1168,4 @@
 
 /datum/movespeed_modifier/freezing_blast
 	multiplicative_slowdown = 1
+	

--- a/code/modules/cargo/exports/weapons.dm
+++ b/code/modules/cargo/exports/weapons.dm
@@ -31,22 +31,28 @@
 	unit_name = "disabler"
 	export_types = list(/obj/item/gun/energy/disabler)
 
+/datum/export/weapon/taser
+	cost = CARGO_CRATE_VALUE * 0.5
+	unit_name = "taser"
+	export_types = list(/obj/item/gun/energy/taser)
+
 /datum/export/weapon/energy_gun
 	cost = CARGO_CRATE_VALUE * 1.5
 	unit_name = "energy gun"
 	export_types = list(/obj/item/gun/energy/e_gun)
 
 /datum/export/weapon/wt550
+	cost = CARGO_CRATE_VALUE * 1.5
 	unit_name = "WT-550 automatic rifle"
 	export_types = list(/obj/item/gun/ballistic/automatic/wt550)
 
 /datum/export/weapon/inferno
-	cost = CARGO_CRATE_VALUE * 1.5
+	cost = CARGO_CRATE_VALUE
 	unit_name = "inferno pistol"
 	export_types = list(/obj/item/gun/energy/laser/thermal/inferno)
 
 /datum/export/weapon/cryo
-	cost = CARGO_CRATE_VALUE * 1.5
+	cost = CARGO_CRATE_VALUE 
 	unit_name = "cryo pistol"
 	export_types = list(/obj/item/gun/energy/laser/thermal/cryo)
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -641,6 +641,7 @@
 /datum/supply_pack/security/armory/wt550
 	name = "WT-550 Auto Rifle Crate"
 	desc = "Contains two high-powered, semiautomatic rifles chambered in 4.6x30mm. Requires Armory access to open."
+	cost = CARGO_CRATE_VALUE * 9
 	contains = list(/obj/item/gun/ballistic/automatic/wt550,
 					/obj/item/gun/ballistic/automatic/wt550)
 	crate_name = "wt-550 auto rifle crate"
@@ -655,10 +656,19 @@
 					/obj/item/ammo_box/magazine/wt550m9)
 	crate_name = "wt-550 standard ammo crate"
 
+/datum/supply_pack/security/taser
+	name = "Taser Crate"
+	desc = "Three old-fashioned taser weapons. Requires Security access to open."
+	cost = CARGO_CRATE_VALUE * 5
+	contains = list(/obj/item/gun/energy/taser,
+					/obj/item/gun/energy/taser,
+					/obj/item/gun/energy/taser)
+	crate_name = "taser crate"
+
 /datum/supply_pack/security/armory/thermal
 	name = "Thermal Pistol Crate"
 	desc = "Contains a pair of holsters each with two experimental thermal pistols, using nanites as the basis for their ammo. Requires Armory access to open."
-	cost = CARGO_CRATE_VALUE * 3.5
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/item/storage/belt/holster/thermal,
 					/obj/item/storage/belt/holster/thermal)
 	crate_name = "thermal pistol crate"

--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -2,7 +2,7 @@
 	projectile_type = /obj/projectile/energy/electrode
 	select_name = "stun"
 	fire_sound = 'sound/weapons/taser.ogg'
-	e_cost = 200
+	e_cost = 250
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/electrode/spec

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -3,11 +3,13 @@
 	icon_state = "spark"
 	color = "#FFFF00"
 	nodamage = FALSE
-	paralyze = 100
+	damage = 20
+	damage_type = STAMINA
+	knockdown = 1
 	stutter = 5
 	jitter = 20
 	hitsound = 'sound/weapons/taserhit.ogg'
-	range = 7
+	range = 5
 	tracer_type = /obj/effect/projectile/tracer/stun
 	muzzle_type = /obj/effect/projectile/muzzle/stun
 	impact_type = /obj/effect/projectile/impact/stun


### PR DESCRIPTION
## About The Pull Request

Cette PR remet les tasers dans le jeu! Ils ont été fortement rééquilibrés pour permettre d'être une outil viable, mais pas pour autant brain-dead.
Egalement, cette PR sert a remettre les prix du WT-500 au Cargo comme a l'origine.

## Why It's Good For The Game

Les tasers ont été une option évidemment trop forte, mais restent clé a l'identité d'SS13 au sens large, il est bon de les retrouver mais bien moins fort : 
- La capacité de tir passe de 5 a 4 coups
- La porté des électrodes passe de 7 a 5 cases 
- Ce prendre une électrode ne paralyse plus, mais fait 20 dégâts de stamina désormais
- Très court knockdown également (moins d'une demi seconde!) mais qui par conséquent désarme  
Cela transforme le taser en une option de stun en parallèle du disabler/baton 
Le disabler pour mettre en stamcrit a distance
Et le taser pour desarmer/ralentir a distance

## Changelog

:cl:
add: Le taser est maintenant achetable au Cargo pour un prix légèrement plus haut que les disablers
add: Trois tasers spawn a l'armurie sur PubbyStation
balance: Les WT-500 ont fortement monté de prix au Cargo, et les Thermal Pistols un petit peu
/:cl:
