### PR TITLE
Add ashstorm immunity to minebots

### DIFF
--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -61,6 +61,8 @@
 	access_card = new /obj/item/card/id/advanced/gold(src)
 	SSid_access.apply_trim_to_card(access_card, /datum/id_trim/job/shaft_miner)
 
+	ADD_TRAIT(src, TRAIT_ASHSTORM_IMMUNE, ROUNDSTART_TRAIT)
+
 	SetCollectBehavior()
 
 /mob/living/simple_animal/hostile/mining_drone/Destroy()


### PR DESCRIPTION
Suggestion pour le minage : rendre les minebots (pas les mineborgs) ashproof.

Les minebots puent déjà bien la merde, mais en plus, ils meurent à la première ash storm.
Leur mettre ashproof leur permettrait d'être moins nul et de survivre jusqu'à qu'ils attrapent les éclats de gibtonite (est-ce qu'ils attrapent encore la gib ?).
ça risque de les rendre plus forts contre la megafauna, mais ils ont pas vraiment de chance de survivre anyway (à part en sentient)