### PR TITLE
Buckshots and Slugs! (+ Fix Electrodes Taser)

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -282,14 +282,14 @@
 
 /datum/supply_pack/security/ammo
 	name = "Ammo Crate"
-	desc = "Contains two 20-round magazines for the WT-550 Auto Rifle, three boxes of rubber ammo and special .38 speedloarders. Requires Security access to open."
+	desc = "Contains two 20-round magazines for the WT-550 Auto Rifle, three boxes of buckshot ammo and special .38 speedloaders. Requires Security access to open."
 	cost = CARGO_CRATE_VALUE * 8
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/ammo_box/magazine/wt550m9,
 					/obj/item/ammo_box/magazine/wt550m9,
-					/obj/item/storage/box/rubbershot,
-					/obj/item/storage/box/rubbershot,
-					/obj/item/storage/box/rubbershot,
+					/obj/item/storage/box/lethalshot,
+					/obj/item/storage/box/lethalshot,
+					/obj/item/storage/box/lethalshot,
 					/obj/item/ammo_box/c38/trac,
 					/obj/item/ammo_box/c38/hotshot,
 					/obj/item/ammo_box/c38/iceblox)

--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -24,3 +24,10 @@
 
 /obj/item/ammo_casing/energy/disabler/hos
 	e_cost = 60
+
+/obj/item/ammo_casing/energy/shock // Specific munition type created for the taser in order to not impede on other weapons
+	projectile_type = /obj/projectile/energy/electrode
+	select_name = "stun"
+	fire_sound = 'sound/weapons/taser.ogg'
+	e_cost = 250
+	harmful = FALSE

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -3,7 +3,7 @@
 	desc = "A low-capacity, energy-based stun gun used by security teams to subdue targets at range."
 	icon_state = "taser"
 	inhand_icon_state = null //so the human update icon uses the icon_state instead.
-	ammo_type = list(/obj/item/ammo_casing/energy/electrode)
+	ammo_type = list(/obj/item/ammo_casing/energy/shock)
 	ammo_x_offset = 3
 
 /obj/item/gun/energy/e_gun/advtaser

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -87,8 +87,8 @@
 /obj/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
 	damage = 7.5
-	wound_bonus = 5
-	bare_wound_bonus = 5
+	wound_bonus = 2.5
+	bare_wound_bonus = 2.5
 	wound_falloff_tile = -2.5 // low damage + additional dropoff will already curb wounding potential anything past point blank
 
 /obj/projectile/bullet/pellet/shotgun_rubbershot

--- a/code/modules/projectiles/projectile/energy/shock.dm
+++ b/code/modules/projectiles/projectile/energy/shock.dm
@@ -1,0 +1,32 @@
+/obj/projectile/energy/shock // Special stats for the taser itself 
+	name = "shock"
+	icon_state = "spark"
+	color = "#FFFF00"
+	nodamage = FALSE
+	damage = 20
+	damage_type = STAMINA
+	knockdown = 1
+	stutter = 5
+	jitter = 20
+	hitsound = 'sound/weapons/taserhit.ogg'
+	range = 5
+	tracer_type = /obj/effect/projectile/tracer/stun
+	muzzle_type = /obj/effect/projectile/muzzle/stun
+	impact_type = /obj/effect/projectile/impact/stun
+
+/obj/projectile/energy/shock/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	if(!ismob(target) || blocked >= 100) //Fully blocked by mob or collided with dense object - burst into sparks!
+		do_sparks(1, TRUE, src)
+	else if(iscarbon(target))
+		var/mob/living/carbon/C = target
+		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "tased", /datum/mood_event/tased)
+		SEND_SIGNAL(C, COMSIG_LIVING_MINOR_SHOCK)
+		if(C.dna && C.dna.check_mutation(/datum/mutation/human/hulk))
+			C.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ), forced = "hulk")
+		else if((C.status_flags & CANKNOCKDOWN) && !HAS_TRAIT(C, TRAIT_STUNIMMUNE))
+			addtimer(CALLBACK(C, /mob/living/carbon.proc/do_jitter_animation, jitter), 5)
+
+/obj/projectile/energy/shock/on_range() //to ensure the bolt sparks when it reaches the end of its range if it didn't hit a target yet
+	do_sparks(1, TRUE, src)
+	..()

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -880,6 +880,22 @@
 	build_path = /obj/item/ammo_casing/shotgun/incendiary
 	category = list("hacked", "Security")
 
+/datum/design/buckshot
+	name = "Buckshot Slug"
+	id = "buckshot"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/buckshot
+	category = list("hacked", "Security")
+
+/datum/design/slug
+	name = "12g Slug"
+	id = "slug"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 4000)
+	build_path = /obj/item/ammo_casing/shotgun
+	category = list("hacked", "Security")
+
 /datum/design/riot_dart
 	name = "Foam Riot Dart"
 	id = "riot_dart"

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -77,6 +77,20 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 	autolathe_exportable = FALSE
 
+/datum/design/buckshot/sec
+	id = "buckshot"
+	build_type = PROTOLATHE | AWAY_LATHE
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	autolathe_exportable = FALSE
+
+/datum/design/slug/sec
+	id = "slug"
+	build_type = PROTOLATHE | AWAY_LATHE
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	autolathe_exportable = FALSE
+
 /datum/design/pin_testing
 	name = "Test-Range Firing Pin"
 	desc = "This safety firing pin allows firearms to be operated within proximity to a firing range."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1428,6 +1428,8 @@
 		"mag_oldsmg",
 		"mag_oldsmg_ap",
 		"mag_oldsmg_ic",
+		"buckshot",
+		"slug",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 


### PR DESCRIPTION
## About The Pull Request

Cette PR rajoute les Buckshots et Slugs sur la station de nouveau avec un léger rééquilibrage!
Vous les trouverez au Cargo, a n'importe quel autolathe, et enfin en Sécurité après que la recherche Ballistic Weaponry a été effectué.
Accessoirement, j'ai peaufiné la PR des tasers pour qu'elles aie une projectile a part (Example, les tourelles tasers de l'IA vont de nouveau stamcrit en un coup)

## Why It's Good For The Game

La sécurité a besoin d'une option létale balistique autre que les lasers, les WT-500 marchent mais ils ont besoin de Cargo pour avoir un fusil (les munitions sont au protolathe par contre), ceci permettra de leur donner un autre outil pour combattre les diverses menaces joyeuses! 

## Changelog

:cl:
add: Buckshots et Slugs disponibles au Cargo et Autolathe
add: Buckshots et Slugs disponibles au Prolathe de Securité derriere la recherche Ballistic Weaponry
balance: Le wound bonus du Buckshot a été divisé par deux (a l'instar du WT-500)
fix: Le projectile du tasers s'appelle maintenant 'shock' afin de laisser les électrodes des autres armes tasers intouchés 
/:cl:
